### PR TITLE
ci: add GitHub Actions workflow for web and mobile tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-web:
+    name: Web Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run web tests
+        run: npm test --workspace=src/web -- --runInBand --ci
+
+  test-mobile:
+    name: Mobile Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run mobile tests
+        run: npm test --workspace=src/mobile -- --runInBand --ci


### PR DESCRIPTION
Adds a CI workflow that runs web and mobile test suites on every push and PR to `main`.

- **Web Tests** job: runs `npm test --workspace=src/web -- --runInBand --ci` (21 tests)
- **Mobile Tests** job: runs `npm test --workspace=src/mobile -- --runInBand --ci` (25 tests)

Both jobs run in parallel on `ubuntu-latest` with Node 20.