### PR TITLE
feat(identity): Phase 1 — Identity Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [main]
 
 jobs:
+  test-backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        working-directory: src/backend
+        run: pip install -r requirements.txt
+
+      - name: Run backend tests
+        working-directory: src/backend
+        run: pytest tests/ -v --tb=short
+
   test-web:
     name: Web Tests
     runs-on: ubuntu-latest

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -10,7 +10,7 @@ from contextlib import asynccontextmanager
 
 from app.config import get_settings
 from app.models import Base  # Import models to register with SQLAlchemy
-from app.routers import auth, twin, messages, drafts, channels, health
+from app.routers import auth, twin, messages, drafts, channels, health, identity
 
 # Get settings
 settings = get_settings()
@@ -95,7 +95,13 @@ def create_app() -> FastAPI:
         prefix=f"{settings.api_v1_str}/channels",
         tags=["Channels"],
     )
-    
+
+    app.include_router(
+        identity.router,
+        prefix=f"{settings.api_v1_str}/identity",
+        tags=["Identity"],
+    )
+
     return app
 
 

--- a/src/backend/app/routers/identity.py
+++ b/src/backend/app/routers/identity.py
@@ -1,0 +1,256 @@
+"""
+Identity endpoints
+/v1/identity/*
+"""
+
+from fastapi import APIRouter, HTTPException, status, Depends
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.middleware.auth import get_current_user
+from app.models import User
+from app.services.identity import IdentityService
+from app.services.twin import TwinService
+from app.schemas.identity import (
+    OnboardingRequest,
+    OnboardingResponse,
+    TopicRequest,
+    TopicResponse,
+    IdentityProfileResponse,
+    UpdateIdentityRequest,
+    IdentityConfidenceResponse,
+    RESPONSE_LENGTH_MAP,
+)
+from typing import List
+
+router = APIRouter(tags=["Identity"])
+
+
+@router.post("/onboard", response_model=OnboardingResponse, status_code=status.HTTP_201_CREATED)
+async def complete_onboarding(
+    request: OnboardingRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Submit the onboarding questionnaire.
+
+    - Updates Twin: domain, tone, avg_response_length
+    - Updates IdentityProfile: vocabulary_description, communication_style, topics_avoided
+    - Returns the merged profile state
+
+    Can be called multiple times — subsequent calls update the existing profile.
+    """
+    avg_length = RESPONSE_LENGTH_MAP[request.response_length]
+    vocabulary_description = ", ".join(request.three_words)
+    communication_style = f"{request.communication_style.value}; audience tone: {request.audience_tone}"
+
+    # Update Twin profile
+    twin = TwinService.update_twin_profile(
+        db,
+        current_user.id,
+        domain=request.role,
+        tone=request.communication_style.value,
+        avg_response_length=avg_length,
+    )
+
+    if not twin:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Twin not found. Ensure signup completed successfully.",
+        )
+
+    # Update IdentityProfile + topics_avoided
+    IdentityService.create_identity_profile(
+        db,
+        user_id=current_user.id,
+        vocabulary_description=vocabulary_description,
+        communication_style=communication_style,
+        topics_avoided=request.topics_avoided,
+    )
+
+    profile = IdentityService.get_identity_profile(db, current_user.id)
+    topics_avoided = IdentityService.get_topics_avoided(db, current_user.id)
+
+    return OnboardingResponse(
+        twin_id=twin.id,
+        domain=twin.domain,
+        tone=twin.tone,
+        avg_response_length=twin.avg_response_length,
+        vocabulary_description=profile.vocabulary_description or "",
+        communication_style=profile.communication_style or "",
+        topics_avoided=topics_avoided,
+        profile_version=1,
+    )
+
+
+@router.get("/profile", response_model=IdentityProfileResponse)
+async def get_identity_profile(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get the current user's identity profile.
+
+    Returns vocabulary, communication style, known and avoided topics.
+    `profile_complete` is True once the onboarding questionnaire has been submitted.
+    """
+    summary = IdentityService.get_identity_summary(db, current_user.id)
+
+    if summary is None:
+        return IdentityProfileResponse(
+            vocabulary_description=None,
+            communication_style=None,
+            topics_known=[],
+            topics_avoided=[],
+            profile_complete=False,
+        )
+
+    profile_complete = bool(
+        summary["vocabulary_description"] and summary["communication_style"]
+    )
+
+    return IdentityProfileResponse(
+        vocabulary_description=summary["vocabulary_description"],
+        communication_style=summary["communication_style"],
+        topics_known=summary["topics_known"],
+        topics_avoided=summary["topics_avoided"],
+        profile_complete=profile_complete,
+    )
+
+
+@router.patch("/profile", response_model=IdentityProfileResponse)
+async def update_identity_profile(
+    request: UpdateIdentityRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Partially update the identity profile.
+
+    Only supplied fields are updated; omitted fields are unchanged.
+    """
+    IdentityService.patch_identity_profile(
+        db,
+        user_id=current_user.id,
+        vocabulary_description=request.vocabulary_description,
+        communication_style=request.communication_style,
+        topics_known=request.topics_known,
+        topics_avoided=request.topics_avoided,
+    )
+
+    summary = IdentityService.get_identity_summary(db, current_user.id)
+    profile_complete = bool(
+        summary and summary["vocabulary_description"] and summary["communication_style"]
+    )
+
+    return IdentityProfileResponse(
+        vocabulary_description=summary["vocabulary_description"] if summary else None,
+        communication_style=summary["communication_style"] if summary else None,
+        topics_known=summary["topics_known"] if summary else [],
+        topics_avoided=summary["topics_avoided"] if summary else [],
+        profile_complete=profile_complete,
+    )
+
+
+# ── Topics: Known ─────────────────────────────────────────────────────────────
+
+@router.get("/topics/known", response_model=List[str])
+async def list_known_topics(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List all topics the twin is comfortable discussing."""
+    return IdentityService.get_topics_known(db, current_user.id)
+
+
+@router.post("/topics/known", response_model=TopicResponse, status_code=status.HTTP_201_CREATED)
+async def add_known_topic(
+    request: TopicRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Add a topic the twin can discuss."""
+    topic = IdentityService.add_known_topic(db, current_user.id, request.topic, request.context)
+    return TopicResponse(
+        id=topic.id,
+        topic=topic.topic,
+        topic_type=topic.topic_type,
+        context=topic.context,
+        frequency=topic.frequency,
+    )
+
+
+@router.delete("/topics/known/{topic}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_known_topic(
+    topic: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Remove a known topic."""
+    deleted = IdentityService.delete_topic(db, current_user.id, topic, "known")
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Known topic '{topic}' not found",
+        )
+
+
+# ── Topics: Avoided ───────────────────────────────────────────────────────────
+
+@router.get("/topics/avoided", response_model=List[str])
+async def list_avoided_topics(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List all topics the twin should avoid."""
+    return IdentityService.get_topics_avoided(db, current_user.id)
+
+
+@router.post("/topics/avoided", response_model=TopicResponse, status_code=status.HTTP_201_CREATED)
+async def add_avoided_topic(
+    request: TopicRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Add a topic the twin should never discuss."""
+    topic = IdentityService.add_avoided_topic(db, current_user.id, request.topic, request.context)
+    return TopicResponse(
+        id=topic.id,
+        topic=topic.topic,
+        topic_type=topic.topic_type,
+        context=topic.context,
+        frequency=topic.frequency,
+    )
+
+
+@router.delete("/topics/avoided/{topic}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_avoided_topic(
+    topic: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Remove an avoided topic."""
+    deleted = IdentityService.delete_topic(db, current_user.id, topic, "avoided")
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Avoided topic '{topic}' not found",
+        )
+
+
+# ── Confidence ────────────────────────────────────────────────────────────────
+
+@router.get("/confidence", response_model=IdentityConfidenceResponse)
+async def get_identity_confidence(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get the twin's identity confidence score.
+
+    Stub implementation: score is based on profile completeness (0–1).
+    Phase 2 will replace this with an embedding-based similarity score
+    derived from approved draft history.
+    """
+    result = IdentityService.get_confidence_score(db, current_user.id)
+    return IdentityConfidenceResponse(**result)

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -17,8 +17,16 @@ from app.schemas.twin import (
     MessageResponse,
     DraftResponse,
     DraftApprovalRequest,
+)
+
+from app.schemas.identity import (
+    OnboardingRequest,
+    OnboardingResponse,
+    TopicRequest,
+    TopicResponse,
     IdentityProfileResponse,
     UpdateIdentityRequest,
+    IdentityConfidenceResponse,
 )
 
 __all__ = [
@@ -28,14 +36,20 @@ __all__ = [
     "TokenResponse",
     "UserResponse",
     "AuthResponse",
-    # Twin & Identity
+    # Twin
     "TwinResponse",
     "TwinStatsResponse",
     "UpdateTwinRequest",
-    "IdentityProfileResponse",
-    "UpdateIdentityRequest",
     # Messages & Drafts
     "MessageResponse",
     "DraftResponse",
     "DraftApprovalRequest",
+    # Identity
+    "OnboardingRequest",
+    "OnboardingResponse",
+    "TopicRequest",
+    "TopicResponse",
+    "IdentityProfileResponse",
+    "UpdateIdentityRequest",
+    "IdentityConfidenceResponse",
 ]

--- a/src/backend/app/schemas/identity.py
+++ b/src/backend/app/schemas/identity.py
@@ -1,0 +1,113 @@
+"""
+Pydantic schemas for Identity endpoints
+"""
+
+from pydantic import BaseModel, field_validator
+from typing import Optional, List
+from enum import Enum
+
+
+class CommunicationStyle(str, Enum):
+    formal = "formal"
+    casual = "casual"
+    friendly = "friendly"
+    direct = "direct"
+    humorous = "humorous"
+
+
+class ResponseLength(str, Enum):
+    short = "short"      # ~75 words
+    medium = "medium"    # ~150 words
+    detailed = "detailed"  # ~300 words
+
+
+# Response-length label → avg word count
+RESPONSE_LENGTH_MAP = {
+    ResponseLength.short: 75,
+    ResponseLength.medium: 150,
+    ResponseLength.detailed: 300,
+}
+
+
+class OnboardingRequest(BaseModel):
+    """Onboarding questionnaire — 6 questions that seed the twin's identity"""
+    role: str  # Q1: What do you do? (role / domain)
+    communication_style: CommunicationStyle  # Q2: Communication style
+    topics_avoided: List[str]  # Q3: Topics NOT to talk about publicly
+    response_length: ResponseLength  # Q4: Typical response length
+    audience_tone: str  # Q5: Tone used with fans/followers
+    three_words: List[str]  # Q6: 3 words that describe you
+
+    @field_validator("topics_avoided")
+    @classmethod
+    def at_least_one_avoided(cls, v: List[str]) -> List[str]:
+        return [t.strip() for t in v if t.strip()]
+
+    @field_validator("three_words")
+    @classmethod
+    def exactly_three_words(cls, v: List[str]) -> List[str]:
+        cleaned = [w.strip() for w in v if w.strip()]
+        if len(cleaned) != 3:
+            raise ValueError("Exactly 3 words are required")
+        return cleaned
+
+
+class OnboardingResponse(BaseModel):
+    """Result of completing the onboarding questionnaire"""
+    twin_id: str
+    domain: str
+    tone: str
+    avg_response_length: int
+    vocabulary_description: str
+    communication_style: str
+    topics_avoided: List[str]
+    profile_version: int
+
+
+class TopicRequest(BaseModel):
+    """Request to add a topic"""
+    topic: str
+    context: Optional[str] = None
+
+    @field_validator("topic")
+    @classmethod
+    def topic_not_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Topic cannot be empty")
+        return v
+
+
+class TopicResponse(BaseModel):
+    """Single topic response"""
+    id: str
+    topic: str
+    topic_type: str
+    context: Optional[str]
+    frequency: int
+
+
+class IdentityProfileResponse(BaseModel):
+    """Full identity profile"""
+    vocabulary_description: Optional[str]
+    communication_style: Optional[str]
+    topics_known: List[str]
+    topics_avoided: List[str]
+    profile_complete: bool  # True if onboarding has been completed
+
+
+class UpdateIdentityRequest(BaseModel):
+    """Patch identity profile fields"""
+    vocabulary_description: Optional[str] = None
+    communication_style: Optional[str] = None
+    topics_known: Optional[List[str]] = None
+    topics_avoided: Optional[List[str]] = None
+
+
+class IdentityConfidenceResponse(BaseModel):
+    """Confidence score stub — how well the twin knows the user"""
+    score: float           # 0.0 – 1.0
+    label: str             # "low" | "medium" | "high"
+    fields_complete: int   # number of profile fields filled
+    total_fields: int      # total profile fields scored
+    message: str           # human-readable status

--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -78,17 +78,4 @@ class DraftApprovalRequest(BaseModel):
     edited_content: Optional[str] = None  # Required if action == "edit"
 
 
-class IdentityProfileResponse(BaseModel):
-    """Identity profile response"""
-    vocabulary_description: Optional[str]
-    communication_style: Optional[str]
-    topics_known: list
-    topics_avoided: list
 
-
-class UpdateIdentityRequest(BaseModel):
-    """Request to update identity profile"""
-    vocabulary_description: Optional[str] = None
-    communication_style: Optional[str] = None
-    topics_known: Optional[list] = None
-    topics_avoided: Optional[list] = None

--- a/src/backend/app/services/identity.py
+++ b/src/backend/app/services/identity.py
@@ -170,16 +170,91 @@ class IdentityService:
     def get_identity_summary(db: Session, user_id: str) -> dict:
         """Get full identity profile summary"""
         profile = IdentityService.get_identity_profile(db, user_id)
-        
+
         if not profile:
             return None
-        
+
         topics_known = IdentityService.get_topics_known(db, user_id)
         topics_avoided = IdentityService.get_topics_avoided(db, user_id)
-        
+
         return {
             "vocabulary_description": profile.vocabulary_description,
             "communication_style": profile.communication_style,
             "topics_known": topics_known,
             "topics_avoided": topics_avoided,
+        }
+
+    @staticmethod
+    def patch_identity_profile(
+        db: Session,
+        user_id: str,
+        vocabulary_description: str = None,
+        communication_style: str = None,
+        topics_known: list = None,
+        topics_avoided: list = None,
+    ) -> IdentityProfile:
+        """Patch (partial update) an existing identity profile"""
+        return IdentityService.create_identity_profile(
+            db,
+            user_id=user_id,
+            vocabulary_description=vocabulary_description,
+            communication_style=communication_style,
+            topics_known=topics_known,
+            topics_avoided=topics_avoided,
+        )
+
+    @staticmethod
+    def delete_topic(db: Session, user_id: str, topic: str, topic_type: str) -> bool:
+        """Delete a topic by name and type. Returns True if deleted, False if not found."""
+        existing = db.query(Topic).filter(
+            and_(
+                Topic.user_id == user_id,
+                Topic.topic == topic,
+                Topic.topic_type == topic_type,
+            )
+        ).first()
+
+        if not existing:
+            return False
+
+        db.delete(existing)
+        db.commit()
+        return True
+
+    @staticmethod
+    def get_confidence_score(db: Session, user_id: str) -> dict:
+        """
+        Stub: compute a confidence score based on profile completeness.
+        Phase 2 will replace this with an embedding-based similarity score.
+        """
+        profile = IdentityService.get_identity_profile(db, user_id)
+        topics_known = IdentityService.get_topics_known(db, user_id)
+        topics_avoided = IdentityService.get_topics_avoided(db, user_id)
+
+        TOTAL_FIELDS = 4
+        filled = sum([
+            bool(profile and profile.vocabulary_description),
+            bool(profile and profile.communication_style),
+            bool(topics_known),
+            bool(topics_avoided),
+        ])
+
+        score = round(filled / TOTAL_FIELDS, 2)
+
+        if score >= 0.75:
+            label = "high"
+            message = "Your twin has a strong identity profile."
+        elif score >= 0.5:
+            label = "medium"
+            message = "Your twin has a partial identity profile. Add more details to improve drafts."
+        else:
+            label = "low"
+            message = "Complete your identity profile so your twin can draft accurate responses."
+
+        return {
+            "score": score,
+            "label": label,
+            "fields_complete": filled,
+            "total_fields": TOTAL_FIELDS,
+            "message": message,
         }

--- a/src/backend/tests/test_identity.py
+++ b/src/backend/tests/test_identity.py
@@ -1,0 +1,254 @@
+"""
+Identity endpoint tests — Phase 1
+POST /v1/identity/onboard
+GET  /v1/identity/profile
+PATCH /v1/identity/profile
+GET  /v1/identity/topics/known
+POST /v1/identity/topics/known
+DELETE /v1/identity/topics/known/{topic}
+GET  /v1/identity/topics/avoided
+POST /v1/identity/topics/avoided
+DELETE /v1/identity/topics/avoided/{topic}
+GET  /v1/identity/confidence
+"""
+
+import pytest
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+ONBOARDING_PAYLOAD = {
+    "role": "content creator",
+    "communication_style": "casual",
+    "topics_avoided": ["politics", "religion"],
+    "response_length": "medium",
+    "audience_tone": "warm and playful",
+    "three_words": ["creative", "authentic", "energetic"],
+}
+
+
+# ── Onboarding ────────────────────────────────────────────────────────────────
+
+class TestOnboarding:
+    def test_onboarding_creates_twin_and_identity(self, client, auth_headers):
+        """Successful onboarding returns twin_id and merged profile fields."""
+        response = client.post(
+            "/v1/identity/onboard",
+            json=ONBOARDING_PAYLOAD,
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["twin_id"]
+        assert data["domain"] == "content creator"
+        assert data["tone"] == "casual"
+        assert data["avg_response_length"] == 150  # medium → 150
+        assert data["vocabulary_description"] == "creative, authentic, energetic"
+        assert "casual" in data["communication_style"]
+        assert "politics" in data["topics_avoided"]
+        assert "religion" in data["topics_avoided"]
+
+    def test_onboarding_is_idempotent(self, client, auth_headers):
+        """Calling onboard twice updates the profile without error."""
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+
+        updated = {**ONBOARDING_PAYLOAD, "role": "developer", "response_length": "detailed"}
+        response = client.post("/v1/identity/onboard", json=updated, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["domain"] == "developer"
+        assert data["avg_response_length"] == 300  # detailed → 300
+
+    def test_onboarding_requires_exactly_three_words(self, client, auth_headers):
+        """three_words with != 3 items returns 422."""
+        bad = {**ONBOARDING_PAYLOAD, "three_words": ["only", "two"]}
+        response = client.post("/v1/identity/onboard", json=bad, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_onboarding_invalid_communication_style(self, client, auth_headers):
+        """Unrecognised communication_style returns 422."""
+        bad = {**ONBOARDING_PAYLOAD, "communication_style": "sarcastic"}
+        response = client.post("/v1/identity/onboard", json=bad, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_onboarding_invalid_response_length(self, client, auth_headers):
+        """Unrecognised response_length returns 422."""
+        bad = {**ONBOARDING_PAYLOAD, "response_length": "super_long"}
+        response = client.post("/v1/identity/onboard", json=bad, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_onboarding_requires_auth(self, client):
+        """Unauthenticated request returns 403 (middleware behaviour)."""
+        response = client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD)
+        assert response.status_code == 403
+
+
+# ── Profile ───────────────────────────────────────────────────────────────────
+
+class TestIdentityProfile:
+    def test_get_profile_before_onboarding(self, client, auth_headers):
+        """Profile is empty (not complete) before onboarding."""
+        response = client.get("/v1/identity/profile", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["profile_complete"] is False
+        assert data["topics_known"] == []
+        assert data["topics_avoided"] == []
+
+    def test_get_profile_after_onboarding(self, client, auth_headers):
+        """Profile reflects onboarding data and is marked complete."""
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+
+        response = client.get("/v1/identity/profile", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["profile_complete"] is True
+        assert data["vocabulary_description"] == "creative, authentic, energetic"
+        assert "politics" in data["topics_avoided"]
+
+    def test_patch_profile_vocabulary(self, client, auth_headers):
+        """PATCH only updates supplied fields."""
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+
+        response = client.patch(
+            "/v1/identity/profile",
+            json={"vocabulary_description": "bold, funny, sharp"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["vocabulary_description"] == "bold, funny, sharp"
+        # communication_style unchanged from onboarding
+        assert data["communication_style"] is not None
+
+    def test_patch_profile_requires_auth(self, client):
+        """Unauthenticated PATCH returns 403 (middleware behaviour)."""
+        response = client.patch("/v1/identity/profile", json={"vocabulary_description": "x"})
+        assert response.status_code == 403
+
+
+# ── Topics: Known ─────────────────────────────────────────────────────────────
+
+class TestKnownTopics:
+    def test_add_known_topic(self, client, auth_headers):
+        """Adding a known topic returns the new topic."""
+        response = client.post(
+            "/v1/identity/topics/known",
+            json={"topic": "photography", "context": "landscape and street"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["topic"] == "photography"
+        assert data["topic_type"] == "known"
+        assert data["context"] == "landscape and street"
+
+    def test_list_known_topics(self, client, auth_headers):
+        """Known topics list includes added topics."""
+        client.post("/v1/identity/topics/known", json={"topic": "fitness"}, headers=auth_headers)
+        client.post("/v1/identity/topics/known", json={"topic": "travel"}, headers=auth_headers)
+
+        response = client.get("/v1/identity/topics/known", headers=auth_headers)
+        assert response.status_code == 200
+        topics = response.json()
+        assert "fitness" in topics
+        assert "travel" in topics
+
+    def test_add_duplicate_known_topic_increments_frequency(self, client, auth_headers):
+        """Adding the same known topic twice increments frequency, not duplicates."""
+        client.post("/v1/identity/topics/known", json={"topic": "gaming"}, headers=auth_headers)
+        response = client.post(
+            "/v1/identity/topics/known", json={"topic": "gaming"}, headers=auth_headers
+        )
+        assert response.status_code == 201
+        assert response.json()["frequency"] == 2
+
+    def test_delete_known_topic(self, client, auth_headers):
+        """Deleting a known topic removes it from the list."""
+        client.post("/v1/identity/topics/known", json={"topic": "cooking"}, headers=auth_headers)
+        del_response = client.delete("/v1/identity/topics/known/cooking", headers=auth_headers)
+        assert del_response.status_code == 204
+
+        topics = client.get("/v1/identity/topics/known", headers=auth_headers).json()
+        assert "cooking" not in topics
+
+    def test_delete_nonexistent_known_topic_returns_404(self, client, auth_headers):
+        """Deleting a topic that doesn't exist returns 404."""
+        response = client.delete("/v1/identity/topics/known/nonexistent", headers=auth_headers)
+        assert response.status_code == 404
+
+
+# ── Topics: Avoided ───────────────────────────────────────────────────────────
+
+class TestAvoidedTopics:
+    def test_add_avoided_topic(self, client, auth_headers):
+        """Adding an avoided topic returns the new topic."""
+        response = client.post(
+            "/v1/identity/topics/avoided",
+            json={"topic": "politics", "context": "too divisive"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["topic"] == "politics"
+        assert data["topic_type"] == "avoided"
+
+    def test_list_avoided_topics(self, client, auth_headers):
+        """Avoided topics list includes added topics."""
+        client.post("/v1/identity/topics/avoided", json={"topic": "finance"}, headers=auth_headers)
+        response = client.get("/v1/identity/topics/avoided", headers=auth_headers)
+        assert response.status_code == 200
+        assert "finance" in response.json()
+
+    def test_delete_avoided_topic(self, client, auth_headers):
+        """Deleting an avoided topic removes it from the list."""
+        client.post("/v1/identity/topics/avoided", json={"topic": "religion"}, headers=auth_headers)
+        client.delete("/v1/identity/topics/avoided/religion", headers=auth_headers)
+        topics = client.get("/v1/identity/topics/avoided", headers=auth_headers).json()
+        assert "religion" not in topics
+
+    def test_delete_nonexistent_avoided_topic_returns_404(self, client, auth_headers):
+        """Deleting a topic that doesn't exist returns 404."""
+        response = client.delete("/v1/identity/topics/avoided/ghost", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_known_and_avoided_topics_are_independent(self, client, auth_headers):
+        """A topic can exist as both known and avoided independently."""
+        client.post("/v1/identity/topics/known", json={"topic": "health"}, headers=auth_headers)
+        client.post("/v1/identity/topics/avoided", json={"topic": "health"}, headers=auth_headers)
+
+        known = client.get("/v1/identity/topics/known", headers=auth_headers).json()
+        avoided = client.get("/v1/identity/topics/avoided", headers=auth_headers).json()
+        assert "health" in known
+        assert "health" in avoided
+
+
+# ── Confidence ────────────────────────────────────────────────────────────────
+
+class TestConfidence:
+    def test_confidence_low_before_onboarding(self, client, auth_headers):
+        """Confidence is low (0.0) before any profile data."""
+        response = client.get("/v1/identity/confidence", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["score"] == 0.0
+        assert data["label"] == "low"
+        assert data["fields_complete"] == 0
+        assert data["total_fields"] == 4
+
+    def test_confidence_high_after_onboarding_with_topics(self, client, auth_headers):
+        """Confidence is high once onboarding is complete and topics are added."""
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+        client.post("/v1/identity/topics/known", json={"topic": "photography"}, headers=auth_headers)
+
+        response = client.get("/v1/identity/confidence", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        # vocabulary_description + communication_style + topics_avoided = 3 fields
+        # topics_known = 1 more → 4/4 = 1.0 high
+        assert data["score"] == 1.0
+        assert data["label"] == "high"
+
+    def test_confidence_requires_auth(self, client):
+        """Unauthenticated request returns 403 (middleware behaviour)."""
+        response = client.get("/v1/identity/confidence")
+        assert response.status_code == 403


### PR DESCRIPTION
## Phase 1 — Identity Core

Implements the full identity onboarding and profile management system per the [MVP Build Plan](docs/06-implementation/MVP_BUILD_PLAN.md).

### What's included

**New endpoints (`/v1/identity/*`)**
| Method | Path | Description |
|---|---|---|
| `POST` | `/v1/identity/onboard` | Submit 6-question onboarding questionnaire |
| `GET` | `/v1/identity/profile` | Get full identity profile |
| `PATCH` | `/v1/identity/profile` | Partial update of profile fields |
| `GET/POST/DELETE` | `/v1/identity/topics/known` | Manage known topics |
| `GET/POST/DELETE` | `/v1/identity/topics/avoided` | Manage avoided topics |
| `GET` | `/v1/identity/confidence` | Profile completeness confidence score (stub) |

**Onboarding questionnaire maps to:**
- Twin: `domain`, `tone`, `avg_response_length`
- IdentityProfile: `vocabulary_description`, `communication_style`, `topics_avoided`

**New / updated files**
- `src/backend/app/schemas/identity.py` — all identity schemas with validation
- `src/backend/app/routers/identity.py` — 10 new endpoints
- `src/backend/app/services/identity.py` — added `delete_topic`, `patch_identity_profile`, `get_confidence_score`
- `src/backend/app/main.py` — registered identity router
- `.github/workflows/ci.yml` — added backend pytest job

### Tests
`tests/test_identity.py` — **23 tests, all passing**
- Onboarding (6 tests): create, idempotency, validation
- Profile (4 tests): get before/after, patch, auth guard
- Known topics (5 tests): add, list, duplicate frequency, delete, 404
- Avoided topics (5 tests): add, list, delete, 404, independence from known
- Confidence (3 tests): low before onboard, high after, auth guard