### PR TITLE
fix(identity): close Phase 1 validation gaps in onboarding/profile patch

### DIFF
--- a/src/backend/app/schemas/identity.py
+++ b/src/backend/app/schemas/identity.py
@@ -41,7 +41,10 @@ class OnboardingRequest(BaseModel):
     @field_validator("topics_avoided")
     @classmethod
     def at_least_one_avoided(cls, v: List[str]) -> List[str]:
-        return [t.strip() for t in v if t.strip()]
+        cleaned = [t.strip() for t in v if t.strip()]
+        if not cleaned:
+            raise ValueError("At least one avoided topic is required")
+        return cleaned
 
     @field_validator("three_words")
     @classmethod

--- a/src/backend/app/services/identity.py
+++ b/src/backend/app/services/identity.py
@@ -9,6 +9,29 @@ from app.models import IdentityProfile, Topic, Twin
 
 class IdentityService:
     """Service for managing twin identity profiles"""
+
+    @staticmethod
+    def _replace_topics(db: Session, user_id: str, topic_type: str, topics: list) -> None:
+        """Replace all topics of a given type with the provided list."""
+        cleaned = []
+        for topic in topics:
+            normalized = topic.strip()
+            if normalized and normalized not in cleaned:
+                cleaned.append(normalized)
+
+        db.query(Topic).filter(
+            and_(
+                Topic.user_id == user_id,
+                Topic.topic_type == topic_type,
+            )
+        ).delete(synchronize_session=False)
+
+        for topic in cleaned:
+            db.add(Topic(
+                user_id=user_id,
+                topic=topic,
+                topic_type=topic_type,
+            ))
     
     @staticmethod
     def get_identity_profile(db: Session, user_id: str) -> IdentityProfile:
@@ -39,50 +62,24 @@ class IdentityService:
         if not profile:
             profile = IdentityProfile(user_id=user_id)
         
-        if vocabulary_description:
+        if vocabulary_description is not None:
             profile.vocabulary_description = vocabulary_description
-        if communication_style:
+        if communication_style is not None:
             profile.communication_style = communication_style
-        if topics_known:
+        if topics_known is not None:
             profile.topics_known_text = ", ".join(topics_known)
-        if topics_avoided:
+        if topics_avoided is not None:
             profile.topics_avoided_text = ", ".join(topics_avoided)
         
         db.add(profile)
         db.flush()
         
-        # Add topics to topics table
-        if topics_known:
-            for topic in topics_known:
-                existing = db.query(Topic).filter(
-                    and_(
-                        Topic.user_id == user_id,
-                        Topic.topic == topic,
-                        Topic.topic_type == "known",
-                    )
-                ).first()
-                if not existing:
-                    db.add(Topic(
-                        user_id=user_id,
-                        topic=topic,
-                        topic_type="known",
-                    ))
-        
-        if topics_avoided:
-            for topic in topics_avoided:
-                existing = db.query(Topic).filter(
-                    and_(
-                        Topic.user_id == user_id,
-                        Topic.topic == topic,
-                        Topic.topic_type == "avoided",
-                    )
-                ).first()
-                if not existing:
-                    db.add(Topic(
-                        user_id=user_id,
-                        topic=topic,
-                        topic_type="avoided",
-                    ))
+        # Replace topics table rows only for provided fields.
+        if topics_known is not None:
+            IdentityService._replace_topics(db, user_id, "known", topics_known)
+
+        if topics_avoided is not None:
+            IdentityService._replace_topics(db, user_id, "avoided", topics_avoided)
         
         db.commit()
         db.refresh(profile)

--- a/src/backend/tests/test_identity.py
+++ b/src/backend/tests/test_identity.py
@@ -76,6 +76,12 @@ class TestOnboarding:
         response = client.post("/v1/identity/onboard", json=bad, headers=auth_headers)
         assert response.status_code == 422
 
+    def test_onboarding_rejects_empty_topics_avoided(self, client, auth_headers):
+        """topics_avoided must contain at least one non-empty topic."""
+        bad = {**ONBOARDING_PAYLOAD, "topics_avoided": ["   ", ""]}
+        response = client.post("/v1/identity/onboard", json=bad, headers=auth_headers)
+        assert response.status_code == 422
+
     def test_onboarding_requires_auth(self, client):
         """Unauthenticated request returns 403 (middleware behaviour)."""
         response = client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD)
@@ -119,6 +125,34 @@ class TestIdentityProfile:
         assert data["vocabulary_description"] == "bold, funny, sharp"
         # communication_style unchanged from onboarding
         assert data["communication_style"] is not None
+
+    def test_patch_profile_allows_clearing_vocabulary_with_empty_string(self, client, auth_headers):
+        """Supplying an empty string should clear vocabulary_description."""
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+
+        response = client.patch(
+            "/v1/identity/profile",
+            json={"vocabulary_description": ""},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["vocabulary_description"] == ""
+
+    def test_patch_profile_allows_clearing_topics_with_empty_list(self, client, auth_headers):
+        """Supplying an empty list should clear known and avoided topics."""
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+        client.post("/v1/identity/topics/known", json={"topic": "photography"}, headers=auth_headers)
+
+        response = client.patch(
+            "/v1/identity/profile",
+            json={"topics_known": [], "topics_avoided": []},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["topics_known"] == []
+        assert data["topics_avoided"] == []
 
     def test_patch_profile_requires_auth(self, client):
         """Unauthenticated PATCH returns 403 (middleware behaviour)."""


### PR DESCRIPTION
## Summary
Fixes 3 confirmed Phase 1 identity bugs found during validation:

1. Onboarding accepted empty `topics_avoided` payloads
2. Profile patch could not clear `vocabulary_description`
3. Profile patch could not clear topics via empty arrays

## Changes
- `src/backend/app/schemas/identity.py`
  - Enforce at least one non-empty `topics_avoided` entry on onboarding
- `src/backend/app/services/identity.py`
  - Respect explicit empty-string updates (`is not None` checks)
  - Replace known/avoided topic sets when arrays are provided (including empty arrays)
- `src/backend/tests/test_identity.py`
  - Added regression tests for all 3 defects

## Validation
- Backend: `93 passed`
- Web: `21 passed`
- Mobile: `25 passed`

Closes #3
Closes #4
Closes #5