### PR TITLE
feat(phase2): Twin Engine v1 context + scoring pipeline

### DIFF
--- a/src/backend/app/services/__init__.py
+++ b/src/backend/app/services/__init__.py
@@ -8,6 +8,7 @@ from app.services.identity import IdentityService
 from app.services.message import MessageService
 from app.services.draft import DraftService
 from app.services.moderation import ModerationService
+from app.services.twin_engine import TwinEngineService
 
 __all__ = [
     "AuthService",
@@ -16,4 +17,5 @@ __all__ = [
     "MessageService",
     "DraftService",
     "ModerationService",
+    "TwinEngineService",
 ]

--- a/src/backend/app/services/twin_engine.py
+++ b/src/backend/app/services/twin_engine.py
@@ -1,0 +1,251 @@
+"""
+Twin Engine service (Phase 2 v1)
+
+Implements a deterministic draft pipeline with:
+- Context loading (identity + topics + recent history)
+- Channel-aware response shaping
+- Confidence factor scoring
+- Safety fallback for avoided topics
+
+This is intentionally provider-agnostic so we can later swap draft generation
+with LiteLLM/Claude while preserving the same pipeline contract.
+"""
+
+from dataclasses import dataclass
+from sqlalchemy.orm import Session
+from app.models import Message, Twin, IdentityProfile, Topic
+from app.services.moderation import ModerationService
+
+
+@dataclass
+class ChannelConstraints:
+    style_hint: str
+    max_words: int
+    emoji_multiplier: float
+    formality_adjustment: int
+
+
+CHANNEL_CONSTRAINTS = {
+    "instagram_dm": ChannelConstraints(
+        style_hint="casual, warm, short",
+        max_words=150,
+        emoji_multiplier=1.2,
+        formality_adjustment=-1,
+    ),
+    "gmail": ChannelConstraints(
+        style_hint="professional, structured, clear",
+        max_words=300,
+        emoji_multiplier=0.2,
+        formality_adjustment=1,
+    ),
+    "twitter_dm": ChannelConstraints(
+        style_hint="concise, punchy, direct",
+        max_words=100,
+        emoji_multiplier=1.0,
+        formality_adjustment=0,
+    ),
+    "whatsapp": ChannelConstraints(
+        style_hint="conversational, warm",
+        max_words=120,
+        emoji_multiplier=1.1,
+        formality_adjustment=-1,
+    ),
+}
+
+
+@dataclass
+class TwinContext:
+    message: Message
+    twin: Twin
+    identity: IdentityProfile
+    known_topics: list[str]
+    avoided_topics: list[str]
+    history: list[Message]
+    constraints: ChannelConstraints
+
+
+class TwinEngineService:
+    """Twin Engine orchestration for draft generation."""
+
+    @staticmethod
+    def _load_context(db: Session, message: Message, user_id: str) -> TwinContext:
+        twin = db.query(Twin).filter(Twin.user_id == user_id).first()
+        identity = db.query(IdentityProfile).filter(IdentityProfile.user_id == user_id).first()
+
+        if not twin:
+            raise ValueError("Twin not found")
+        if not identity:
+            raise ValueError("Identity profile not found")
+
+        known_topics = [
+            t.topic.lower() for t in db.query(Topic).filter(
+                Topic.user_id == user_id,
+                Topic.topic_type == "known",
+            ).all()
+        ]
+        avoided_topics = [
+            t.topic.lower() for t in db.query(Topic).filter(
+                Topic.user_id == user_id,
+                Topic.topic_type == "avoided",
+            ).all()
+        ]
+
+        history = db.query(Message).filter(
+            Message.user_id == user_id,
+            Message.sender_id == message.sender_id,
+            Message.channel == message.channel,
+            Message.id != message.id,
+        ).order_by(Message.created_at.desc()).limit(5).all()
+
+        constraints = CHANNEL_CONSTRAINTS.get(
+            message.channel,
+            ChannelConstraints(
+                style_hint="neutral, clear",
+                max_words=150,
+                emoji_multiplier=1.0,
+                formality_adjustment=0,
+            ),
+        )
+
+        return TwinContext(
+            message=message,
+            twin=twin,
+            identity=identity,
+            known_topics=known_topics,
+            avoided_topics=avoided_topics,
+            history=history,
+            constraints=constraints,
+        )
+
+    @staticmethod
+    def _build_prompts(ctx: TwinContext) -> tuple[str, str]:
+        system_prompt = (
+            f"You are the digital twin of this user. "
+            f"Tone={ctx.twin.tone}; Domain={ctx.twin.domain}; "
+            f"AvgLength={ctx.twin.avg_response_length}; "
+            f"ChannelHint={ctx.constraints.style_hint}; "
+            f"AvoidedTopics={', '.join(ctx.avoided_topics) or 'none'}."
+        )
+
+        history_preview = " | ".join([m.content[:80] for m in reversed(ctx.history)])
+        user_prompt = (
+            f"Incoming message from {ctx.message.sender_name}: {ctx.message.content}\n"
+            f"History: {history_preview or 'No prior history'}"
+        )
+
+        return system_prompt, user_prompt
+
+    @staticmethod
+    def _contains_avoided_topic(content: str, avoided_topics: list[str]) -> bool:
+        lower = content.lower()
+        return any(topic and topic in lower for topic in avoided_topics)
+
+    @staticmethod
+    def _topic_match_score(content: str, known_topics: list[str]) -> float:
+        if not known_topics:
+            return 0.5
+        lower = content.lower()
+        if any(topic and topic in lower for topic in known_topics):
+            return 0.9
+        return 0.45
+
+    @staticmethod
+    def _apply_word_limit(text: str, max_words: int) -> str:
+        words = text.split()
+        if len(words) <= max_words:
+            return text
+        return " ".join(words[:max_words]).rstrip() + "..."
+
+    @staticmethod
+    def _generate_draft(ctx: TwinContext) -> tuple[str, dict]:
+        if TwinEngineService._contains_avoided_topic(ctx.message.content, ctx.avoided_topics):
+            draft = "That's not something I cover — let me get back to you"
+            factors = {
+                "topic_known": 0.2,
+                "length_match": 1.0,
+                "tone_match": 0.7,
+                "no_avoided_topics": 0.0,
+                "sample_similarity": 0.5,
+            }
+            return draft, factors
+
+        if ctx.message.channel == "gmail":
+            opening = f"Hi {ctx.message.sender_name},"
+            body = "Thanks for your message. I appreciate you reaching out."
+            follow_up = "Here is a quick response from my side based on what you shared."
+            closing = "Best regards"
+            draft = f"{opening}\n\n{body} {follow_up}\n\n{closing}"
+        else:
+            body = "Thanks for the message. I appreciate you reaching out and sharing this."
+            follow_up = "Happy to help and continue the conversation from here."
+            draft = f"Hey {ctx.message.sender_name}! {body} {follow_up}"
+
+        draft = TwinEngineService._apply_word_limit(draft, ctx.constraints.max_words)
+
+        target_len = max(ctx.twin.avg_response_length, 1)
+        actual_len = max(len(draft.split()), 1)
+        length_delta = abs(actual_len - target_len) / target_len
+        length_match = max(0.0, min(1.0, 1.0 - length_delta))
+
+        factors = {
+            "topic_known": TwinEngineService._topic_match_score(ctx.message.content, ctx.known_topics),
+            "length_match": round(length_match, 2),
+            "tone_match": 0.8 if ctx.twin.tone else 0.6,
+            "no_avoided_topics": 1.0,
+            "sample_similarity": 0.7 if ctx.history else 0.5,
+        }
+        return draft, factors
+
+    @staticmethod
+    def _compute_overall_confidence(factors: dict) -> float:
+        # Weighted average aligned with Phase 2 confidence factors.
+        score = (
+            0.30 * factors["topic_known"] +
+            0.20 * factors["length_match"] +
+            0.20 * factors["tone_match"] +
+            0.20 * factors["no_avoided_topics"] +
+            0.10 * factors["sample_similarity"]
+        )
+        return round(max(0.0, min(1.0, score)), 2)
+
+    @staticmethod
+    def run_twin_pipeline(db: Session, message_id: str, user_id: str) -> dict:
+        """
+        Run Phase 2 Twin Engine v1 for a message.
+
+        Returns a dict with draft output, confidence metadata, and moderation result.
+        """
+        message = db.query(Message).filter(Message.id == message_id, Message.user_id == user_id).first()
+        if not message:
+            raise ValueError("Message not found")
+
+        ctx = TwinEngineService._load_context(db, message, user_id)
+        system_prompt, user_prompt = TwinEngineService._build_prompts(ctx)
+        draft, factors = TwinEngineService._generate_draft(ctx)
+
+        confidence_score = TwinEngineService._compute_overall_confidence(factors)
+        confidence_label = ModerationService.get_confidence_label(confidence_score)
+
+        moderation_passed, flags, risk_score = ModerationService.check_content_safety(draft)
+
+        if not moderation_passed:
+            confidence_score = min(confidence_score, 0.3)
+            confidence_label = ModerationService.get_confidence_label(confidence_score)
+
+        reasoning = (
+            f"Generated with channel='{message.channel}', topic_known={factors['topic_known']}, "
+            f"no_avoided_topics={factors['no_avoided_topics']}, moderation_risk={risk_score}."
+        )
+
+        return {
+            "twin_id": ctx.twin.id,
+            "draft": draft,
+            "confidence_score": confidence_score,
+            "confidence_label": confidence_label,
+            "confidence_reasoning": reasoning,
+            "confidence_factors": factors,
+            "moderation_passed": moderation_passed,
+            "moderation_flags": flags,
+            "system_prompt": system_prompt,
+            "user_prompt": user_prompt,
+        }

--- a/src/backend/app/tasks/draft_generation.py
+++ b/src/backend/app/tasks/draft_generation.py
@@ -8,8 +8,8 @@ from celery import shared_task
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.config import get_settings
-from app.models import Message, Draft, Twin, IdentityProfile
-from app.services import DraftService, ModerationService, IdentityService
+from app.models import Message
+from app.services import DraftService, TwinEngineService
 import logging
 
 logger = logging.getLogger(__name__)
@@ -48,52 +48,21 @@ def generate_draft_for_message(self, message_id: str, user_id: str):
                 logger.error(f"Message {message_id} not found")
                 return {"status": "error", "reason": "Message not found"}
             
-            # 2. Fetch twin + identity
-            twin = db.query(Twin).filter(Twin.user_id == user_id).first()
-            identity = db.query(IdentityProfile).filter(IdentityProfile.user_id == user_id).first()
-            
-            if not twin or not identity:
-                logger.error(f"Twin or identity not found for user {user_id}")
-                return {"status": "error", "reason": "Twin or identity not found"}
-            
-            # 3. Run moderation on incoming message
-            moderation_passed, flags, risk_score = ModerationService.check_content_safety(
-                message.content
-            )
-            
-            logger.info(
-                f"Message {message_id} moderation: passed={moderation_passed}, "
-                f"risk={risk_score}, flags={len(flags)}"
-            )
-            
-            # 4. Generate draft using placeholder engine
-            # Phase 1: Replace with real LangGraph orchestration
-            draft_content = _generate_draft_placeholder(
-                message=message,
-                twin=twin,
-                identity=identity,
-            )
-            
-            # 5. Calculate confidence score
-            confidence_score = ModerationService.calculate_confidence_score(
-                user_interaction_count=1,
-                moderation_passed=moderation_passed,
-                topic_match=0.5,  # Placeholder: would come from semantic matching
-            )
-            confidence_label = ModerationService.get_confidence_label(confidence_score)
+            # 2. Run Twin Engine Phase 2 pipeline
+            pipeline = TwinEngineService.run_twin_pipeline(db, message.id, user_id)
             
             # 6. Create draft
             draft = DraftService.create_draft(
                 db=db,
                 message_id=message_id,
                 user_id=user_id,
-                twin_id=twin.id,
-                content=draft_content,
-                confidence_score=confidence_score,
-                confidence_label=confidence_label,
-                confidence_reasoning="Phase 0 placeholder generation",
-                moderation_passed=moderation_passed,
-                moderation_flags=[{"pattern": f.get("pattern"), "risk": f.get("risk")} for f in flags],
+                twin_id=pipeline["twin_id"],
+                content=pipeline["draft"],
+                confidence_score=pipeline["confidence_score"],
+                confidence_label=pipeline["confidence_label"],
+                confidence_reasoning=pipeline["confidence_reasoning"],
+                moderation_passed=pipeline["moderation_passed"],
+                moderation_flags=[{"pattern": f.get("pattern"), "risk": f.get("risk")} for f in pipeline["moderation_flags"]],
             )
             
             # Mark message as draft_ready
@@ -105,8 +74,8 @@ def generate_draft_for_message(self, message_id: str, user_id: str):
             return {
                 "status": "success",
                 "draft_id": draft.id,
-                "confidence": confidence_score,
-                "moderation_passed": moderation_passed,
+                "confidence": pipeline["confidence_score"],
+                "moderation_passed": pipeline["moderation_passed"],
             }
         
         finally:
@@ -128,41 +97,3 @@ def process_draft_generation(message_id: str, user_id: str):
     return generate_draft_for_message.delay(message_id, user_id)
 
 
-def _generate_draft_placeholder(message, twin, identity) -> str:
-    """
-    Placeholder draft generation for Phase 0
-    
-    Phase 0: Rule-based template responses
-    Phase 1: Full LangGraph twin engine with:
-    - Memory retrieval system
-    - Context window management
-    - Style/tone application
-    - Topic awareness
-    - User feedback incorporation
-    
-    Args:
-        message: Incoming message
-        twin: Twin profile
-        identity: Twin identity profile
-    
-    Returns:
-        Generated draft response
-    """
-    # Phase 0 placeholder: Echo with twin personality
-    sender_name = message.sender_name or "Friend"
-    
-    templates = {
-        "professional": f"Thank you for reaching out, {sender_name}. I appreciate your message.",
-        "casual": f"Hey {sender_name}! Thanks for the message.",
-        "creative": f"Interesting point, {sender_name}! Let me think about that...",
-        "supportive": f"I'm here for you, {sender_name}. Let's talk about this.",
-    }
-    
-    tone = twin.tone.lower() if twin.tone else "professional"
-    template = templates.get(tone, templates["professional"])
-    
-    # Append message preview
-    preview = message.content[:50] + "..." if len(message.content) > 50 else message.content
-    draft = f"{template}\n\nRe: {preview}"
-    
-    return draft

--- a/src/backend/tests/test_services.py
+++ b/src/backend/tests/test_services.py
@@ -9,6 +9,7 @@ from app.services.identity import IdentityService
 from app.services.message import MessageService
 from app.services.draft import DraftService
 from app.services.moderation import ModerationService
+from app.services.twin_engine import TwinEngineService
 from app.schemas.auth import SignupRequest, LoginRequest
 
 
@@ -463,6 +464,81 @@ class TestDraftService:
         assert summary["pending"] == 3
         assert summary["approved"] == 0
         assert summary["rejected"] == 0
+
+
+class TestTwinEngineService:
+    """Test Phase 2 twin engine pipeline."""
+
+    def test_pipeline_returns_draft_and_confidence(self, test_db, test_user):
+        """Pipeline should return draft content and confidence metadata."""
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "instagram_dm",
+            "sender_1",
+            "Alex",
+            "Hey, can you help me with content strategy?",
+            {},
+        )
+
+        result = TwinEngineService.run_twin_pipeline(test_db, message.id, test_user.id)
+
+        assert result["twin_id"] == test_user.twin.id
+        assert isinstance(result["draft"], str)
+        assert len(result["draft"]) > 0
+        assert 0.0 <= result["confidence_score"] <= 1.0
+        assert result["confidence_label"] in ["High", "Medium", "Low"]
+        assert "topic_known" in result["confidence_factors"]
+
+    def test_pipeline_uses_avoided_topic_fallback(self, test_db, test_user):
+        """Avoided topics should trigger safe fallback response."""
+        IdentityService.add_avoided_topic(test_db, test_user.id, "politics")
+
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "instagram_dm",
+            "sender_2",
+            "Sam",
+            "What is your take on politics this week?",
+            {},
+        )
+
+        result = TwinEngineService.run_twin_pipeline(test_db, message.id, test_user.id)
+        assert "That's not something I cover" in result["draft"]
+        assert result["confidence_factors"]["no_avoided_topics"] == 0.0
+
+    def test_pipeline_topic_match_increases_score(self, test_db, test_user):
+        """Known topic match should produce a higher topic factor."""
+        IdentityService.add_known_topic(test_db, test_user.id, "photography")
+
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "instagram_dm",
+            "sender_3",
+            "Jamie",
+            "Any photography tips for portraits?",
+            {},
+        )
+
+        result = TwinEngineService.run_twin_pipeline(test_db, message.id, test_user.id)
+        assert result["confidence_factors"]["topic_known"] >= 0.9
+
+    def test_pipeline_respects_channel_word_limit(self, test_db, test_user):
+        """Generated draft should respect channel max words."""
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "twitter_dm",
+            "sender_4",
+            "Taylor",
+            "Please share your detailed perspective on audience engagement and retention strategies.",
+            {},
+        )
+
+        result = TwinEngineService.run_twin_pipeline(test_db, message.id, test_user.id)
+        assert len(result["draft"].split()) <= 100
 
 
 class TestModerationService:


### PR DESCRIPTION
## Phase 2 Kickoff: Twin Engine v1

Implements the first real Twin Engine pipeline and replaces the Phase 0 placeholder draft generator.

### What shipped
- New `TwinEngineService`:
  - Context loading (`twin`, `identity`, topics, sender history)
  - Channel constraints (`instagram_dm`, `gmail`, `twitter_dm`, `whatsapp`)
  - Prompt assembly (`system_prompt`, `user_prompt`) for provider swap-in later
  - Draft generation with avoided-topic fallback
  - Confidence factors + weighted overall score
  - Safety moderation on generated draft
- `draft_generation` task now uses `TwinEngineService.run_twin_pipeline`
- Service export updated in `app/services/__init__.py`
- Added Phase 2 service tests:
  - pipeline output contract
  - avoided-topic fallback
  - known-topic factor boost
  - channel word-limit enforcement

### Validation
- `pytest tests/test_services.py` ✅
- `pytest tests/test_endpoints.py` ✅
- `pytest tests/` ✅ (97 passed)

### Notes
This is intentionally deterministic and provider-agnostic. Next Phase 2 increment can swap the draft generation step to LiteLLM/Claude while keeping the same context/prompt/confidence contract.