### PR TITLE
feat(phase2): persist draft token/cost controls and expose spend stats

### DIFF
--- a/src/backend/app/models/draft.py
+++ b/src/backend/app/models/draft.py
@@ -2,7 +2,7 @@
 Draft model — drafted responses awaiting approval
 """
 
-from sqlalchemy import Column, String, Text, ForeignKey, Float, Boolean, JSON, Index
+from sqlalchemy import Column, String, Text, ForeignKey, Float, Boolean, JSON, Index, Integer
 from sqlalchemy.orm import relationship
 from app.models.base import BaseModel
 
@@ -28,6 +28,19 @@ class Draft(BaseModel):
     # Safety
     moderation_passed = Column(Boolean, default=False, nullable=False)
     moderation_flags = Column(JSON, default=list, nullable=False)  # List of flags if any
+
+    # Generation controls & cost telemetry
+    generation_source = Column(String, nullable=True)  # llm | deterministic
+    llm_model = Column(String, nullable=True)
+    fallback_reason = Column(String, nullable=True)
+    llm_calls = Column(Integer, nullable=True)
+    parse_retry_count = Column(Integer, nullable=True)
+    llm_latency_ms = Column(Integer, nullable=True)
+    pipeline_latency_ms = Column(Integer, nullable=True)
+    estimated_input_tokens = Column(Integer, nullable=True)
+    estimated_output_tokens = Column(Integer, nullable=True)
+    estimated_total_tokens = Column(Integer, nullable=True)
+    estimated_cost_usd = Column(Float, nullable=True)
     
     # Status
     status = Column(String, default="pending_approval", nullable=False)  # pending_approval, approved, edited, rejected, sent

--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -31,6 +31,9 @@ class TwinStatsResponse(BaseModel):
     total_messages: int
     pending_drafts: int
     processed_drafts: int
+    total_estimated_tokens: int
+    total_estimated_cost_usd: float
+    fallback_rate: float
 
 
 class UpdateTwinRequest(BaseModel):
@@ -67,6 +70,17 @@ class DraftResponse(BaseModel):
     confidence_label: str
     moderation_passed: bool
     status: str
+    generation_source: Optional[str]
+    llm_model: Optional[str]
+    fallback_reason: Optional[str]
+    llm_calls: Optional[int]
+    parse_retry_count: Optional[int]
+    llm_latency_ms: Optional[int]
+    pipeline_latency_ms: Optional[int]
+    estimated_input_tokens: Optional[int]
+    estimated_output_tokens: Optional[int]
+    estimated_total_tokens: Optional[int]
+    estimated_cost_usd: Optional[float]
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/src/backend/app/services/draft.py
+++ b/src/backend/app/services/draft.py
@@ -47,6 +47,17 @@ class DraftService:
         confidence_reasoning: str = None,
         moderation_passed: bool = False,
         moderation_flags: list = None,
+        generation_source: str = None,
+        llm_model: str = None,
+        fallback_reason: str = None,
+        llm_calls: int = None,
+        parse_retry_count: int = None,
+        llm_latency_ms: int = None,
+        pipeline_latency_ms: int = None,
+        estimated_input_tokens: int = None,
+        estimated_output_tokens: int = None,
+        estimated_total_tokens: int = None,
+        estimated_cost_usd: float = None,
     ) -> Draft:
         """
         Create a new draft response
@@ -72,6 +83,17 @@ class DraftService:
             confidence_reasoning=confidence_reasoning,
             moderation_passed=moderation_passed,
             moderation_flags=moderation_flags or [],
+            generation_source=generation_source,
+            llm_model=llm_model,
+            fallback_reason=fallback_reason,
+            llm_calls=llm_calls,
+            parse_retry_count=parse_retry_count,
+            llm_latency_ms=llm_latency_ms,
+            pipeline_latency_ms=pipeline_latency_ms,
+            estimated_input_tokens=estimated_input_tokens,
+            estimated_output_tokens=estimated_output_tokens,
+            estimated_total_tokens=estimated_total_tokens,
+            estimated_cost_usd=estimated_cost_usd,
             status="pending_approval",
         )
         

--- a/src/backend/app/services/twin.py
+++ b/src/backend/app/services/twin.py
@@ -3,6 +3,7 @@ Twin management service
 """
 
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from app.models import Twin, User
 
 
@@ -57,6 +58,22 @@ class TwinService:
             Draft.user_id == user_id,
             Draft.status == "pending_approval"
         ).count()
+
+        total_drafts = db.query(Draft).filter(Draft.user_id == user_id).count()
+        fallback_count = db.query(Draft).filter(
+            Draft.user_id == user_id,
+            Draft.generation_source == "deterministic",
+        ).count()
+
+        total_tokens = db.query(func.coalesce(func.sum(Draft.estimated_total_tokens), 0)).filter(
+            Draft.user_id == user_id,
+        ).scalar() or 0
+
+        total_cost = db.query(func.coalesce(func.sum(Draft.estimated_cost_usd), 0.0)).filter(
+            Draft.user_id == user_id,
+        ).scalar() or 0.0
+
+        fallback_rate = round((fallback_count / total_drafts), 4) if total_drafts > 0 else 0.0
         
         return {
             "twin_id": twin.id,
@@ -66,6 +83,9 @@ class TwinService:
             "total_messages": total_messages,
             "pending_drafts": pending_drafts,
             "processed_drafts": processed_drafts,
+            "total_estimated_tokens": int(total_tokens),
+            "total_estimated_cost_usd": float(round(total_cost, 8)),
+            "fallback_rate": fallback_rate,
         }
     
     @staticmethod

--- a/src/backend/app/services/twin_engine.py
+++ b/src/backend/app/services/twin_engine.py
@@ -29,6 +29,12 @@ except Exception:  # pragma: no cover
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
+# Estimated USD per 1M tokens (approx placeholders; tune per provider billing).
+MODEL_COST_PER_MILLION = {
+    "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
+    "gpt-5": {"input": 5.0, "output": 15.0},
+}
+
 
 @dataclass
 class ChannelConstraints:
@@ -79,6 +85,20 @@ class TwinContext:
 
 class TwinEngineService:
     """Twin Engine orchestration for draft generation."""
+
+    @staticmethod
+    def _estimate_tokens(text: str) -> int:
+        # Heuristic: ~4 chars/token, minimum 1 token for non-empty text.
+        if not text:
+            return 0
+        return max(1, int(len(text) / 4))
+
+    @staticmethod
+    def _estimate_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+        rates = MODEL_COST_PER_MILLION.get(model, {"input": 3.0, "output": 15.0})
+        input_cost = (input_tokens / 1_000_000) * rates["input"]
+        output_cost = (output_tokens / 1_000_000) * rates["output"]
+        return round(input_cost + output_cost, 8)
 
     @staticmethod
     def _extract_json_object(text: str) -> dict:
@@ -377,12 +397,30 @@ class TwinEngineService:
         )
 
         pipeline_latency_ms = int((time.perf_counter() - pipeline_start) * 1000)
+        llm_model = settings.default_llm_model if generation_source == "llm" else "deterministic-fallback"
+        fallback_reason = generation_metrics.get("fallback_reason") if generation_source != "llm" else None
+
+        estimated_input_tokens = TwinEngineService._estimate_tokens(system_prompt) + TwinEngineService._estimate_tokens(user_prompt)
+        estimated_output_tokens = TwinEngineService._estimate_tokens(draft)
+        estimated_total_tokens = estimated_input_tokens + estimated_output_tokens
+        estimated_cost_usd = TwinEngineService._estimate_cost_usd(
+            settings.default_llm_model,
+            estimated_input_tokens,
+            estimated_output_tokens,
+        ) if generation_source == "llm" else 0.0
+
         metrics = {
             "pipeline_latency_ms": pipeline_latency_ms,
             "llm_latency_ms": generation_metrics.get("llm_latency_ms", 0),
             "parse_retry_count": generation_metrics.get("parse_retry_count", 0),
             "llm_calls": generation_metrics.get("llm_calls", 0),
             "used_fallback": generation_source != "llm",
+            "llm_model": llm_model,
+            "fallback_reason": fallback_reason,
+            "estimated_input_tokens": estimated_input_tokens,
+            "estimated_output_tokens": estimated_output_tokens,
+            "estimated_total_tokens": estimated_total_tokens,
+            "estimated_cost_usd": estimated_cost_usd,
         }
 
         logger.info(
@@ -409,5 +447,11 @@ class TwinEngineService:
             "system_prompt": system_prompt,
             "user_prompt": user_prompt,
             "generation_source": generation_source,
+            "llm_model": llm_model,
+            "fallback_reason": fallback_reason,
+            "estimated_input_tokens": estimated_input_tokens,
+            "estimated_output_tokens": estimated_output_tokens,
+            "estimated_total_tokens": estimated_total_tokens,
+            "estimated_cost_usd": estimated_cost_usd,
             "metrics": metrics,
         }

--- a/src/backend/app/tasks/draft_generation.py
+++ b/src/backend/app/tasks/draft_generation.py
@@ -63,6 +63,17 @@ def generate_draft_for_message(self, message_id: str, user_id: str):
                 confidence_reasoning=pipeline["confidence_reasoning"],
                 moderation_passed=pipeline["moderation_passed"],
                 moderation_flags=[{"pattern": f.get("pattern"), "risk": f.get("risk")} for f in pipeline["moderation_flags"]],
+                generation_source=pipeline.get("generation_source"),
+                llm_model=pipeline.get("llm_model"),
+                fallback_reason=pipeline.get("fallback_reason"),
+                llm_calls=pipeline.get("metrics", {}).get("llm_calls"),
+                parse_retry_count=pipeline.get("metrics", {}).get("parse_retry_count"),
+                llm_latency_ms=pipeline.get("metrics", {}).get("llm_latency_ms"),
+                pipeline_latency_ms=pipeline.get("metrics", {}).get("pipeline_latency_ms"),
+                estimated_input_tokens=pipeline.get("estimated_input_tokens"),
+                estimated_output_tokens=pipeline.get("estimated_output_tokens"),
+                estimated_total_tokens=pipeline.get("estimated_total_tokens"),
+                estimated_cost_usd=pipeline.get("estimated_cost_usd"),
             )
             
             # Mark message as draft_ready

--- a/src/backend/tests/test_pipeline_tasks.py
+++ b/src/backend/tests/test_pipeline_tasks.py
@@ -49,6 +49,9 @@ class TestDraftGenerationTaskPipeline:
             assert stored_draft.message_id == message.id
             assert stored_draft.user_id == test_user.id
             assert stored_draft.content
+            assert stored_draft.generation_source in ["deterministic", "llm"]
+            assert stored_draft.estimated_total_tokens is not None
+            assert stored_draft.estimated_cost_usd is not None
         finally:
             db.close()
 

--- a/src/backend/tests/test_services.py
+++ b/src/backend/tests/test_services.py
@@ -202,6 +202,9 @@ class TestTwinService:
         assert "tone" in stats
         assert "total_messages" in stats
         assert "pending_drafts" in stats
+        assert "total_estimated_tokens" in stats
+        assert "total_estimated_cost_usd" in stats
+        assert "fallback_rate" in stats
         assert stats["status"] == "active"
         assert stats["total_messages"] == 0
         assert stats["pending_drafts"] == 0
@@ -489,6 +492,8 @@ class TestTwinEngineService:
         assert 0.0 <= result["confidence_score"] <= 1.0
         assert result["confidence_label"] in ["High", "Medium", "Low"]
         assert "topic_known" in result["confidence_factors"]
+        assert result["estimated_total_tokens"] >= 0
+        assert result["estimated_cost_usd"] >= 0
 
     def test_pipeline_uses_avoided_topic_fallback(self, test_db, test_user):
         """Avoided topics should trigger safe fallback response."""


### PR DESCRIPTION
## Summary
Implements cost/control tracking for Phase 2 draft generation and exposes spend/fallback metrics in API responses.

## Changes
- `src/backend/app/models/draft.py`
  - Added persisted generation telemetry fields:
    - `generation_source`, `llm_model`, `fallback_reason`
    - `llm_calls`, `parse_retry_count`, `llm_latency_ms`, `pipeline_latency_ms`
    - `estimated_input_tokens`, `estimated_output_tokens`, `estimated_total_tokens`, `estimated_cost_usd`

- `src/backend/app/services/twin_engine.py`
  - Added token estimation heuristic and model-cost estimation helper
  - Emits model/fallback/token/cost data in pipeline result
  - Includes telemetry in metrics payload

- `src/backend/app/tasks/draft_generation.py`
  - Persists generation metadata into `Draft` via `DraftService.create_draft`

- `src/backend/app/services/draft.py`
  - `create_draft` now accepts and persists generation metadata

- `src/backend/app/services/twin.py`
  - `get_twin_stats` now includes:
    - `total_estimated_tokens`
    - `total_estimated_cost_usd`
    - `fallback_rate`

- `src/backend/app/schemas/twin.py`
  - Extended `DraftResponse` with generation metadata fields
  - Extended `TwinStatsResponse` with aggregate spend/fallback fields

- Tests
  - `src/backend/tests/test_pipeline_tasks.py`: verifies persisted cost/control fields
  - `src/backend/tests/test_services.py`: verifies telemetry + twin stats keys

## Validation
- `pytest tests/test_pipeline_tasks.py` -> 3 passed
- `pytest tests/test_services.py` -> 37 passed
- `pytest tests/test_endpoints.py` -> 27 passed
- `pytest tests/` -> 103 passed