### PR TITLE
feat(phase2): harden draft approval loop telemetry

### DIFF
--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -34,6 +34,9 @@ class TwinStatsResponse(BaseModel):
     total_estimated_tokens: int
     total_estimated_cost_usd: float
     fallback_rate: float
+    generation_source_breakdown: dict[str, int]
+    model_breakdown: dict[str, int]
+    fallback_reason_breakdown: dict[str, int]
 
 
 class UpdateTwinRequest(BaseModel):

--- a/src/backend/app/services/draft.py
+++ b/src/backend/app/services/draft.py
@@ -8,6 +8,20 @@ from app.models import Draft, Message, Twin, AuditLog
 
 class DraftService:
     """Service for managing draft responses"""
+
+    @staticmethod
+    def _build_audit_details(draft: Draft) -> dict:
+        """Build consistent audit payload for draft lifecycle actions."""
+        return {
+            "confidence_score": draft.confidence_score,
+            "generation_source": draft.generation_source,
+            "llm_model": draft.llm_model,
+            "fallback_reason": draft.fallback_reason,
+            "estimated_total_tokens": draft.estimated_total_tokens,
+            "estimated_cost_usd": draft.estimated_cost_usd,
+            "status": draft.status,
+            "user_action": draft.user_action,
+        }
     
     @staticmethod
     def get_draft(db: Session, draft_id: str) -> Draft:
@@ -122,7 +136,7 @@ class DraftService:
             action="approve_draft",
             resource_type="Draft",
             resource_id=draft_id,
-            details={"confidence_score": draft.confidence_score},
+            details=DraftService._build_audit_details(draft),
         )
         db.add(audit)
         db.commit()
@@ -149,7 +163,7 @@ class DraftService:
             action="reject_draft",
             resource_type="Draft",
             resource_id=draft_id,
-            details={},
+            details=DraftService._build_audit_details(draft),
         )
         db.add(audit)
         db.commit()
@@ -182,7 +196,7 @@ class DraftService:
             action="edit_draft",
             resource_type="Draft",
             resource_id=draft_id,
-            details={},
+            details=DraftService._build_audit_details(draft),
         )
         db.add(audit)
         db.commit()
@@ -209,7 +223,7 @@ class DraftService:
             action="skip_draft",
             resource_type="Draft",
             resource_id=draft_id,
-            details={},
+            details=DraftService._build_audit_details(draft),
         )
         db.add(audit)
         db.commit()

--- a/src/backend/app/services/twin.py
+++ b/src/backend/app/services/twin.py
@@ -52,7 +52,7 @@ class TwinService:
         total_messages = db.query(Message).filter(Message.user_id == user_id).count()
         processed_drafts = db.query(Draft).filter(
             Draft.user_id == user_id,
-            Draft.status.in_(["approved", "sent"])
+            Draft.status.in_(["approved", "edited", "sent"])
         ).count()
         pending_drafts = db.query(Draft).filter(
             Draft.user_id == user_id,
@@ -74,6 +74,25 @@ class TwinService:
         ).scalar() or 0.0
 
         fallback_rate = round((fallback_count / total_drafts), 4) if total_drafts > 0 else 0.0
+
+        generation_source_breakdown = {}
+        for source, count in db.query(Draft.generation_source, func.count(Draft.id)).filter(
+            Draft.user_id == user_id,
+        ).group_by(Draft.generation_source).all():
+            generation_source_breakdown[source or "unknown"] = count
+
+        model_breakdown = {}
+        for model, count in db.query(Draft.llm_model, func.count(Draft.id)).filter(
+            Draft.user_id == user_id,
+        ).group_by(Draft.llm_model).all():
+            model_breakdown[model or "unknown"] = count
+
+        fallback_reason_breakdown = {}
+        for reason, count in db.query(Draft.fallback_reason, func.count(Draft.id)).filter(
+            Draft.user_id == user_id,
+            Draft.fallback_reason.is_not(None),
+        ).group_by(Draft.fallback_reason).all():
+            fallback_reason_breakdown[reason] = count
         
         return {
             "twin_id": twin.id,
@@ -86,6 +105,9 @@ class TwinService:
             "total_estimated_tokens": int(total_tokens),
             "total_estimated_cost_usd": float(round(total_cost, 8)),
             "fallback_rate": fallback_rate,
+            "generation_source_breakdown": generation_source_breakdown,
+            "model_breakdown": model_breakdown,
+            "fallback_reason_breakdown": fallback_reason_breakdown,
         }
     
     @staticmethod

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -5,6 +5,11 @@ Integration tests for backend API endpoints
 import pytest
 from fastapi.testclient import TestClient
 
+from app.models import AuditLog, Draft
+from app.models.user import User
+from app.services.draft import DraftService
+from app.services.message import MessageService
+
 
 class TestAuthEndpoints:
     """Test authentication endpoints"""
@@ -169,6 +174,12 @@ class TestTwinEndpoints:
         assert "tone" in data
         assert "total_messages" in data
         assert "pending_drafts" in data
+        assert "total_estimated_tokens" in data
+        assert "total_estimated_cost_usd" in data
+        assert "fallback_rate" in data
+        assert "generation_source_breakdown" in data
+        assert "model_breakdown" in data
+        assert "fallback_reason_breakdown" in data
 
     def test_update_twin_profile(self, client, auth_headers, test_twin_data):
         """Test updating twin profile"""
@@ -221,6 +232,45 @@ class TestMessageEndpoints:
 class TestDraftEndpoints:
     """Test draft endpoints"""
 
+    @staticmethod
+    def _get_authenticated_user(test_db, test_user_data):
+        return test_db.query(User).filter(User.email == test_user_data["email"]).first()
+
+    @staticmethod
+    def _seed_draft(test_db, test_user, **overrides):
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "instagram_dm",
+            overrides.pop("sender_id", "sender_seed"),
+            overrides.pop("sender_name", "Seed Sender"),
+            overrides.pop("content", "Hello from seed"),
+            {},
+        )
+        return DraftService.create_draft(
+            test_db,
+            message.id,
+            test_user.id,
+            test_user.twin.id,
+            overrides.pop("draft_content", "Seed draft reply"),
+            confidence_score=overrides.pop("confidence_score", 0.82),
+            confidence_label=overrides.pop("confidence_label", "High"),
+            confidence_reasoning=overrides.pop("confidence_reasoning", "Seeded for endpoint tests"),
+            moderation_passed=overrides.pop("moderation_passed", True),
+            moderation_flags=overrides.pop("moderation_flags", []),
+            generation_source=overrides.pop("generation_source", "llm"),
+            llm_model=overrides.pop("llm_model", "claude-sonnet-4-6"),
+            fallback_reason=overrides.pop("fallback_reason", None),
+            llm_calls=overrides.pop("llm_calls", 1),
+            parse_retry_count=overrides.pop("parse_retry_count", 0),
+            llm_latency_ms=overrides.pop("llm_latency_ms", 250),
+            pipeline_latency_ms=overrides.pop("pipeline_latency_ms", 400),
+            estimated_input_tokens=overrides.pop("estimated_input_tokens", 120),
+            estimated_output_tokens=overrides.pop("estimated_output_tokens", 40),
+            estimated_total_tokens=overrides.pop("estimated_total_tokens", 160),
+            estimated_cost_usd=overrides.pop("estimated_cost_usd", 0.00096),
+        )
+
     def test_get_pending_drafts(self, client, auth_headers):
         """Test getting pending drafts"""
         response = client.get("/v1/drafts/pending", headers=auth_headers)
@@ -228,6 +278,133 @@ class TestDraftEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)
+
+    def test_get_draft_returns_generation_metadata(self, client, auth_headers, test_db, test_user_data):
+        """Draft detail endpoint should return persisted generation/cost metadata."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user, fallback_reason="llm_disabled", generation_source="deterministic")
+
+        response = client.get(f"/v1/drafts/{draft.id}", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["generation_source"] == "deterministic"
+        assert data["llm_model"] == "claude-sonnet-4-6"
+        assert data["fallback_reason"] == "llm_disabled"
+        assert data["estimated_total_tokens"] == 160
+        assert data["estimated_cost_usd"] == 0.00096
+
+    def test_pending_drafts_returns_generation_metadata(self, client, auth_headers, test_db, test_user_data):
+        """Pending drafts list should expose generation/cost metadata for dashboard use."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        self._seed_draft(test_db, current_user, generation_source="llm")
+
+        response = client.get("/v1/drafts/pending", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["generation_source"] == "llm"
+        assert data[0]["estimated_total_tokens"] == 160
+
+    def test_approve_draft_updates_status_and_audit(self, client, auth_headers, test_db, test_user_data):
+        """Approve action should update status and create audit details with cost metadata."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/approve",
+            headers=auth_headers,
+            json={"action": "approve"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "approved"
+
+        audit = test_db.query(AuditLog).filter(AuditLog.resource_id == draft.id, AuditLog.action == "approve_draft").first()
+        assert audit is not None
+        assert audit.details["generation_source"] == "llm"
+        assert audit.details["estimated_total_tokens"] == 160
+
+    def test_edit_draft_requires_content_and_marks_edited(self, client, auth_headers, test_db, test_user_data):
+        """Edit action should require content and persist edited status once supplied."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+
+        missing = client.post(
+            f"/v1/drafts/{draft.id}/approve",
+            headers=auth_headers,
+            json={"action": "edit"},
+        )
+        assert missing.status_code == 400
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/approve",
+            headers=auth_headers,
+            json={"action": "edit", "edited_content": "Human-approved rewrite"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "edited"
+
+    def test_reject_and_skip_draft_follow_state_machine(self, client, auth_headers, test_db, test_user_data):
+        """Reject and skip should close the draft and block re-processing."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        reject_draft = self._seed_draft(test_db, current_user, sender_id="reject_sender")
+        skip_draft = self._seed_draft(test_db, current_user, sender_id="skip_sender")
+
+        reject_response = client.post(
+            f"/v1/drafts/{reject_draft.id}/approve",
+            headers=auth_headers,
+            json={"action": "reject"},
+        )
+        assert reject_response.status_code == 200
+        assert reject_response.json()["status"] == "rejected"
+
+        skip_response = client.post(
+            f"/v1/drafts/{skip_draft.id}/approve",
+            headers=auth_headers,
+            json={"action": "skip"},
+        )
+        assert skip_response.status_code == 200
+        assert skip_response.json()["status"] == "rejected"
+
+        second_attempt = client.post(
+            f"/v1/drafts/{skip_draft.id}/approve",
+            headers=auth_headers,
+            json={"action": "approve"},
+        )
+        assert second_attempt.status_code == 400
+
+    def test_twin_stats_breaks_down_generation_sources_and_models(self, client, auth_headers, test_db, test_user_data):
+        """Twin stats should expose dashboard-friendly breakdowns."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        self._seed_draft(test_db, current_user, generation_source="llm", llm_model="claude-sonnet-4-6", estimated_total_tokens=200, estimated_cost_usd=0.001)
+        deterministic = self._seed_draft(
+            test_db,
+            current_user,
+            sender_id="fallback_sender",
+            generation_source="deterministic",
+            llm_model="deterministic-fallback",
+            fallback_reason="llm_disabled",
+            estimated_total_tokens=80,
+            estimated_cost_usd=0.0,
+        )
+        deterministic.status = "edited"
+        test_db.commit()
+
+        response = client.get("/v1/twin/stats", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["processed_drafts"] == 1
+        assert data["total_estimated_tokens"] == 280
+        assert data["total_estimated_cost_usd"] == 0.001
+        assert data["generation_source_breakdown"]["llm"] == 1
+        assert data["generation_source_breakdown"]["deterministic"] == 1
+        assert data["model_breakdown"]["claude-sonnet-4-6"] == 1
+        assert data["model_breakdown"]["deterministic-fallback"] == 1
+        assert data["fallback_reason_breakdown"]["llm_disabled"] == 1
 
     def test_approve_draft(self, client, auth_headers):
         """Test approving a draft"""

--- a/src/backend/tests/test_services.py
+++ b/src/backend/tests/test_services.py
@@ -3,6 +3,7 @@ Unit tests for backend services
 """
 
 import pytest
+from app.models import AuditLog
 from app.services.auth import AuthService
 from app.services.twin import TwinService
 from app.services.identity import IdentityService
@@ -401,6 +402,9 @@ class TestDraftService:
         approved_draft = draft_service.approve_draft(test_db, draft.id, test_user.id)
         
         assert approved_draft.status == "approved"
+        audit = test_db.query(AuditLog).filter(AuditLog.resource_id == draft.id, AuditLog.action == "approve_draft").first()
+        assert audit is not None
+        assert "generation_source" in audit.details
 
     def test_reject_draft(self, test_db, test_user):
         """Test rejecting a draft"""
@@ -444,6 +448,51 @@ class TestDraftService:
         
         assert edited_draft.status == "edited"
         assert edited_draft.edited_content == "Hello there!"
+
+    def test_skip_draft_records_skip_action(self, test_db, test_user):
+        """Skip should preserve rejected status but keep distinct user_action and audit trail."""
+        from app.services.message import MessageService
+
+        message = MessageService.create_message(
+            test_db, test_user.id, "instagram_dm", "sender", "John", "Hello", {}
+        )
+        draft = DraftService.create_draft(
+            test_db, message.id, test_user.id, test_user.twin.id, "Hi!", 0.8, True
+        )
+
+        skipped_draft = DraftService.skip_draft(test_db, draft.id, test_user.id)
+
+        assert skipped_draft.status == "rejected"
+        assert skipped_draft.user_action == "skip"
+        audit = test_db.query(AuditLog).filter(AuditLog.resource_id == draft.id, AuditLog.action == "skip_draft").first()
+        assert audit is not None
+
+    def test_get_twin_stats_counts_edited_as_processed(self, test_db, test_user):
+        """Edited drafts should count as processed in twin stats."""
+        message = MessageService.create_message(
+            test_db, test_user.id, "instagram_dm", "sender_stats", "John", "Hello", {}
+        )
+        draft = DraftService.create_draft(
+            test_db,
+            message.id,
+            test_user.id,
+            test_user.twin.id,
+            "Hi!",
+            confidence_score=0.8,
+            moderation_passed=True,
+            generation_source="deterministic",
+            llm_model="deterministic-fallback",
+            fallback_reason="llm_disabled",
+            estimated_total_tokens=100,
+            estimated_cost_usd=0.0,
+        )
+        DraftService.edit_draft(test_db, draft.id, test_user.id, "Updated")
+
+        stats = TwinService.get_twin_stats(test_db, test_user.id)
+
+        assert stats["processed_drafts"] == 1
+        assert stats["generation_source_breakdown"]["deterministic"] >= 1
+        assert stats["fallback_reason_breakdown"]["llm_disabled"] >= 1
 
     def test_get_draft_summary(self, test_db, test_user):
         """Test getting draft summary statistics"""


### PR DESCRIPTION
## Summary
- add approval-loop audit metadata so approve, reject, edit, and skip actions all persist consistent telemetry details
- expose twin stats breakdowns for generation source, model usage, and fallback reasons while counting edited drafts as processed
- strengthen backend endpoint and service coverage for draft lifecycle transitions and stats payloads

## Validation
- python -m pytest tests/test_endpoints.py -q
- python -m pytest tests/test_services.py -q
- python -m pytest tests/ -q