### PR TITLE
feat(phase3): dashboard polling and foreground refresh

### DIFF
--- a/src/mobile/app/(dashboard)/index.tsx
+++ b/src/mobile/app/(dashboard)/index.tsx
@@ -12,6 +12,7 @@ import {
   ActivityIndicator,
   Alert,
   TextInput,
+  AppState,
 } from 'react-native'
 import { useMobileAuth } from '@/lib/auth-context'
 import { apiClient } from '@selph/shared'
@@ -96,6 +97,24 @@ export default function DashboardScreen() {
     setStats(statsResponse.data)
     setPendingDrafts(draftsResponse.data)
   }
+
+  // Auto-refresh: foreground resume + 30-second interval
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        refreshDashboard()
+      }
+    })
+
+    const intervalId = setInterval(() => {
+      refreshDashboard()
+    }, 30_000)
+
+    return () => {
+      subscription.remove()
+      clearInterval(intervalId)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleDraftAction = async (
     draftId: string,

--- a/src/mobile/tests/dashboard-screen.test.tsx
+++ b/src/mobile/tests/dashboard-screen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Alert } from 'react-native'
+import { Alert, AppState } from 'react-native'
 import { fireEvent, render, waitFor } from '@testing-library/react-native'
 import DashboardScreen from '../app/(dashboard)/index'
 import { useMobileAuth } from '@/lib/auth-context'
@@ -210,5 +210,38 @@ describe('Dashboard screen (mobile)', () => {
     await waitFor(() => {
       expect(getByText('Draft approved successfully.')).toBeTruthy()
     })
+  })
+
+  it('refreshes dashboard when app returns to foreground', async () => {
+    let appStateHandler: ((state: string) => void) | undefined
+    const removeMock = jest.fn()
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(
+      (_event: string, handler: (state: string) => void) => {
+        appStateHandler = handler
+        return { remove: removeMock } as any
+      }
+    )
+
+    primeDashboardFetches()
+    // prime data returned by the foreground refresh
+    ;(apiClient.get as jest.Mock)
+      .mockResolvedValueOnce(statsResponse)
+      .mockResolvedValueOnce({ data: [] })
+
+    const { getByText } = render(<DashboardScreen />)
+
+    await waitFor(() => {
+      expect(getByText('Twin Profile')).toBeTruthy()
+    })
+
+    // simulate app coming to foreground
+    appStateHandler?.('active')
+
+    await waitFor(() => {
+      // initial: 3 calls; foreground refresh: 2 calls = 5 total
+      expect((apiClient.get as jest.Mock).mock.calls.length).toBe(5)
+    })
+
+    jest.restoreAllMocks()
   })
 })

--- a/src/web/app/dashboard/page.tsx
+++ b/src/web/app/dashboard/page.tsx
@@ -89,6 +89,26 @@ export default function DashboardPage() {
     setPendingDrafts(draftsResponse.data);
   };
 
+  // Auto-refresh: 30-second interval + visibility-change revalidation
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      refreshDashboard();
+    }, 30_000);
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        refreshDashboard();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleDraftAction = async (
     draftId: string,
     action: "approve" | "reject" | "edit" | "skip",

--- a/src/web/tests/dashboard-page.test.tsx
+++ b/src/web/tests/dashboard-page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import DashboardPage from '../app/dashboard/page'
 import { useAuth } from '@/lib/auth-context'
 import { apiClient } from '@selph/shared'
@@ -163,5 +163,31 @@ describe('Dashboard page (web)', () => {
     await waitFor(() => {
       expect(screen.getByText('Draft approved successfully.')).toBeInTheDocument()
     })
+  })
+
+  it('polls dashboard data every 30 seconds', async () => {
+    jest.useFakeTimers()
+    primeDashboardFetches()
+    // prime the data returned by the automatic refresh
+    ;(apiClient.get as jest.Mock)
+      .mockResolvedValueOnce(statsResponse)
+      .mockResolvedValueOnce({ data: [] })
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Twin Profile')).toBeInTheDocument()
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(30_000)
+    })
+
+    await waitFor(() => {
+      // initial fetch: 3 calls (twin + stats + drafts); poll refresh: 2 calls (stats + drafts)
+      expect((apiClient.get as jest.Mock).mock.calls.length).toBe(5)
+    })
+
+    jest.useRealTimers()
   })
 })


### PR DESCRIPTION
## Summary
Adds automatic data revalidation to both dashboards so the pending-draft queue stays current without a manual page refresh.

### Web (src/web/app/dashboard/page.tsx)
- **30-second \setInterval\** calls \efreshDashboard()\ (stats + drafts) on each tick
- **\isibilitychange\** listener fires an immediate refresh when the browser tab regains focus
- Cleanup returns \clearInterval\ + \emoveEventListener\ on unmount

### Mobile (\src/mobile/app/(dashboard)/index.tsx\)
- **\AppState\ listener** on \'change'\ → refreshes when \
extState === 'active'\ (app returns to foreground)
- **30-second \setInterval\** as a background heartbeat
- Cleanup calls \subscription.remove()\ + \clearInterval\

### Tests
| Suite | Before | After |
|-------|--------|-------|
| Backend | 111 ✅ | 111 ✅ (unchanged) |
| Web | 22 ✅ | 23 ✅ (+polling-interval test) |
| Mobile | 26 ✅ | 27 ✅ (+foreground-refresh test) |

No backend schema changes required.