### PR TITLE
feat: Phase 6 PR A voice foundation abstraction and schema

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -74,6 +74,12 @@ GOOGLE_OAUTH_CLIENT_SECRET=your_client_secret
 GOOGLE_OAUTH_REDIRECT_URI=http://localhost:8000/v1/channels/gmail/callback
 GOOGLE_PUBSUB_TOPIC=projects/your-project-id/topics/gmail-push
 
+# Voice Clone (Phase 6 foundation)
+# Use mock for local/testing. Set to elevenlabs when integrating provider APIs.
+VOICE_PROVIDER=mock
+ELEVENLABS_API_KEY=
+VOICE_DEFAULT_MODEL_ID=
+
 # ============================================================================
 # APPLICATION SETTINGS
 # ============================================================================

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -70,6 +70,11 @@ class Settings(BaseSettings):
     google_oauth_client_secret: str = ""
     google_oauth_redirect_uri: str = ""  # e.g. https://api.selph.ai/v1/channels/gmail/callback
     google_pubsub_topic: str = ""  # e.g. projects/selph/topics/gmail-push
+
+    # Voice Clone (Phase 6)
+    voice_provider: str = "mock"  # mock | elevenlabs
+    elevenlabs_api_key: str = ""
+    voice_default_model_id: str = ""
     
     # Logging
     log_level: str = "INFO"

--- a/src/backend/app/models/draft.py
+++ b/src/backend/app/models/draft.py
@@ -41,6 +41,13 @@ class Draft(BaseModel):
     estimated_output_tokens = Column(Integer, nullable=True)
     estimated_total_tokens = Column(Integer, nullable=True)
     estimated_cost_usd = Column(Float, nullable=True)
+
+    # Voice synthesis (Phase 6)
+    voice_status = Column(String, default="not_requested", nullable=False)
+    voice_audio_url = Column(Text, nullable=True)
+    voice_provider = Column(String, nullable=True)
+    voice_model_id = Column(String, nullable=True)
+    voice_error = Column(Text, nullable=True)
     
     # Status
     status = Column(String, default="pending_approval", nullable=False)  # pending_approval, approved, edited, rejected, sent

--- a/src/backend/app/models/identity_profile.py
+++ b/src/backend/app/models/identity_profile.py
@@ -26,6 +26,9 @@ class IdentityProfile(BaseModel):
     embedding_model = Column(String, default="text-embedding-3-small", nullable=False)
     topics_known_text = Column(Text, nullable=True)  # Raw text for regeneration
     topics_avoided_text = Column(Text, nullable=True)
+    voice_model_id = Column(String, nullable=True)
+    voice_provider = Column(String, default="mock", nullable=False)
+    voice_sample_url = Column(Text, nullable=True)
     
     # Relationships
     user = relationship("User", back_populates="identity_profile")

--- a/src/backend/app/tasks/voice_synthesis.py
+++ b/src/backend/app/tasks/voice_synthesis.py
@@ -1,16 +1,22 @@
 """
 Voice synthesis tasks
-Phase 0: Stub for phase 6 implementation
-Future: Integrate ElevenLabs or Azure Speech for voice cloning
+Phase 6 PR A: provider abstraction + DB orchestration foundation
 """
 
 from celery import shared_task
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 import logging
+
+from app.config import get_settings
+from app.models import Draft, IdentityProfile
+from app.voice.base import VoiceSynthesisRequest
+from app.voice.registry import get_voice_provider
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(bind=True, max_retries=2)
+@shared_task(bind=True, max_retries=2, queue="voice_synthesis")
 def synthesize_voice(
     self,
     draft_id: str,
@@ -20,30 +26,72 @@ def synthesize_voice(
 ):
     """
     Synthesize voice for a draft response
-    
-    Phase 0: Placeholder
-    Phase 6: Full voice cloning implementation with:
-    - Voice profile management
-    - ElevenLabs API integration (or Azure Speech)
-    - Audio file storage in Cloudflare R2
-    - Sample quality checks
-    
+
     Args:
         draft_id: Draft to generate voice for
         user_id: Owner of the twin
         text: Text to synthesize
-        voice_profile_id: Pre-recorded voice profile ID
+        voice_profile_id: Optional provider model ID override
     
     Returns:
-        dict with audio_url (Phase 6)
+        dict with synthesis status and metadata
     """
-    logger.info(f"[PHASE 6 STUB] Voice synthesis task queued for draft {draft_id}")
-    
-    return {
-        "status": "phase_6_placeholder",
-        "draft_id": draft_id,
-        "message": "Voice synthesis coming in Phase 6",
-    }
+    settings = get_settings()
+    if not settings.feature_voice_clone:
+        logger.info("Voice clone feature disabled; skipping draft %s", draft_id)
+        return {
+            "status": "disabled",
+            "draft_id": draft_id,
+            "reason": "FEATURE_VOICE_CLONE is disabled",
+        }
+
+    engine = create_engine(settings.database_url)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    try:
+        draft = db.query(Draft).filter(Draft.id == draft_id, Draft.user_id == user_id).first()
+        if not draft:
+            return {"status": "error", "draft_id": draft_id, "reason": "Draft not found"}
+
+        profile = db.query(IdentityProfile).filter(IdentityProfile.user_id == user_id).first()
+        provider_name = profile.voice_provider if profile and profile.voice_provider else settings.voice_provider
+        model_id = voice_profile_id or (profile.voice_model_id if profile else None) or settings.voice_default_model_id
+
+        provider = get_voice_provider(provider_name)
+        result = provider.synthesize(
+            VoiceSynthesisRequest(
+                text=text,
+                voice_model_id=model_id,
+                user_id=user_id,
+                draft_id=draft_id,
+            )
+        )
+
+        draft.voice_provider = result.provider
+        draft.voice_model_id = model_id
+
+        if result.ok:
+            draft.voice_status = "generated"
+            draft.voice_audio_url = result.audio_url
+            draft.voice_error = None
+            status = "success"
+        else:
+            draft.voice_status = "failed"
+            draft.voice_error = result.error
+            status = "failed"
+
+        db.commit()
+
+        return {
+            "status": status,
+            "draft_id": draft_id,
+            "provider": result.provider,
+            "voice_status": draft.voice_status,
+            "audio_url": draft.voice_audio_url,
+            "error": draft.voice_error,
+        }
+    finally:
+        db.close()
 
 
 @shared_task

--- a/src/backend/app/voice/__init__.py
+++ b/src/backend/app/voice/__init__.py
@@ -1,0 +1,11 @@
+"""Voice synthesis provider abstraction and registry."""
+
+from app.voice.base import VoiceProvider, VoiceSynthesisRequest, VoiceSynthesisResult
+from app.voice.registry import get_voice_provider
+
+__all__ = [
+    "VoiceProvider",
+    "VoiceSynthesisRequest",
+    "VoiceSynthesisResult",
+    "get_voice_provider",
+]

--- a/src/backend/app/voice/base.py
+++ b/src/backend/app/voice/base.py
@@ -1,0 +1,37 @@
+"""Base interfaces for voice synthesis providers."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class VoiceSynthesisRequest:
+    """Normalized request payload for voice synthesis."""
+
+    text: str
+    voice_model_id: str | None = None
+    user_id: str | None = None
+    draft_id: str | None = None
+
+
+@dataclass
+class VoiceSynthesisResult:
+    """Normalized synthesis response for task orchestration."""
+
+    ok: bool
+    provider: str
+    audio_url: str | None = None
+    error: str | None = None
+
+
+class VoiceProvider(ABC):
+    """Abstract provider contract for voice synthesis backends."""
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def synthesize(self, request: VoiceSynthesisRequest) -> VoiceSynthesisResult:
+        raise NotImplementedError

--- a/src/backend/app/voice/providers/elevenlabs.py
+++ b/src/backend/app/voice/providers/elevenlabs.py
@@ -1,0 +1,45 @@
+"""ElevenLabs provider adapter for future production voice cloning."""
+
+import logging
+
+from app.voice.base import VoiceProvider, VoiceSynthesisRequest, VoiceSynthesisResult
+
+logger = logging.getLogger(__name__)
+
+
+class ElevenLabsVoiceProvider(VoiceProvider):
+    """Phase 6 foundation adapter.
+
+    This is intentionally conservative for PR A: it validates config and returns
+    a structured not-configured/not-implemented response when prerequisites are
+    missing.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key or ""
+
+    @property
+    def provider_name(self) -> str:
+        return "elevenlabs"
+
+    def synthesize(self, request: VoiceSynthesisRequest) -> VoiceSynthesisResult:
+        if not self._api_key:
+            return VoiceSynthesisResult(
+                ok=False,
+                provider=self.provider_name,
+                error="ELEVENLABS_API_KEY is not configured",
+            )
+
+        if not request.voice_model_id:
+            return VoiceSynthesisResult(
+                ok=False,
+                provider=self.provider_name,
+                error="voice_model_id is required for ElevenLabs synthesis",
+            )
+
+        logger.info("ElevenLabs adapter foundation called for draft=%s", request.draft_id)
+        return VoiceSynthesisResult(
+            ok=False,
+            provider=self.provider_name,
+            error="ElevenLabs synthesis implementation is planned in Phase 6 PR B",
+        )

--- a/src/backend/app/voice/providers/mock.py
+++ b/src/backend/app/voice/providers/mock.py
@@ -1,0 +1,19 @@
+"""Deterministic mock voice provider for local development and tests."""
+
+from app.voice.base import VoiceProvider, VoiceSynthesisRequest, VoiceSynthesisResult
+
+
+class MockVoiceProvider(VoiceProvider):
+    """Returns a deterministic mock URL with no external calls."""
+
+    @property
+    def provider_name(self) -> str:
+        return "mock"
+
+    def synthesize(self, request: VoiceSynthesisRequest) -> VoiceSynthesisResult:
+        draft_id = request.draft_id or "unknown"
+        return VoiceSynthesisResult(
+            ok=True,
+            provider=self.provider_name,
+            audio_url=f"mock://voice/{draft_id}.mp3",
+        )

--- a/src/backend/app/voice/registry.py
+++ b/src/backend/app/voice/registry.py
@@ -1,0 +1,19 @@
+"""Provider registry for voice synthesis backends."""
+
+from app.config import get_settings
+from app.voice.base import VoiceProvider
+from app.voice.providers.mock import MockVoiceProvider
+from app.voice.providers.elevenlabs import ElevenLabsVoiceProvider
+
+
+def get_voice_provider(provider_name: str | None = None) -> VoiceProvider:
+    """Return a concrete provider instance based on config or explicit name."""
+    settings = get_settings()
+    selected = (provider_name or settings.voice_provider or "mock").strip().lower()
+
+    if selected == "mock":
+        return MockVoiceProvider()
+    if selected == "elevenlabs":
+        return ElevenLabsVoiceProvider(api_key=settings.elevenlabs_api_key)
+
+    raise ValueError(f"Unsupported voice provider '{selected}'")

--- a/src/backend/migrations/versions/002_phase6_voice_foundation.py
+++ b/src/backend/migrations/versions/002_phase6_voice_foundation.py
@@ -1,0 +1,43 @@
+"""Phase 6 voice foundation fields
+
+Revision ID: 002_phase6_voice_foundation
+Revises: 001_initial_schema
+Create Date: 2026-04-28 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "002_phase6_voice_foundation"
+down_revision = "001_initial_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # identity_profiles
+    op.add_column("identity_profiles", sa.Column("voice_model_id", sa.String(), nullable=True))
+    op.add_column("identity_profiles", sa.Column("voice_provider", sa.String(), nullable=False, server_default="mock"))
+    op.add_column("identity_profiles", sa.Column("voice_sample_url", sa.Text(), nullable=True))
+
+    # drafts
+    op.add_column("drafts", sa.Column("voice_status", sa.String(), nullable=False, server_default="not_requested"))
+    op.add_column("drafts", sa.Column("voice_audio_url", sa.Text(), nullable=True))
+    op.add_column("drafts", sa.Column("voice_provider", sa.String(), nullable=True))
+    op.add_column("drafts", sa.Column("voice_model_id", sa.String(), nullable=True))
+    op.add_column("drafts", sa.Column("voice_error", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "voice_error")
+    op.drop_column("drafts", "voice_model_id")
+    op.drop_column("drafts", "voice_provider")
+    op.drop_column("drafts", "voice_audio_url")
+    op.drop_column("drafts", "voice_status")
+
+    op.drop_column("identity_profiles", "voice_sample_url")
+    op.drop_column("identity_profiles", "voice_provider")
+    op.drop_column("identity_profiles", "voice_model_id")

--- a/src/backend/tests/test_phase6_voice_foundation.py
+++ b/src/backend/tests/test_phase6_voice_foundation.py
@@ -1,0 +1,150 @@
+"""Phase 6 PR A tests: voice provider abstraction and task foundation."""
+
+from unittest.mock import patch
+
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Draft, IdentityProfile, Message, Twin
+from app.services import MessageService, DraftService
+from app.tasks import voice_synthesis
+from app.voice.registry import get_voice_provider
+
+
+def _bind_task_engine_to_test_db(monkeypatch, test_db):
+    engine = test_db.get_bind()
+    monkeypatch.setattr(voice_synthesis, "create_engine", lambda _url: engine)
+
+
+class TestVoiceProviderRegistry:
+    def test_get_default_provider_returns_mock(self):
+        provider = get_voice_provider("mock")
+        assert provider.provider_name == "mock"
+
+    def test_unknown_provider_raises(self):
+        try:
+            get_voice_provider("unknown-provider")
+            assert False, "Expected ValueError for unknown provider"
+        except ValueError as exc:
+            assert "Unsupported voice provider" in str(exc)
+
+
+class TestVoiceSynthesisTaskFoundation:
+    def _seed_draft(self, test_db, test_user):
+        twin = test_db.query(Twin).filter(Twin.user_id == test_user.id).first()
+        if not twin:
+            twin = Twin(user_id=test_user.id, status="active")
+            test_db.add(twin)
+            test_db.flush()
+
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "gmail",
+            "sender-voice-1",
+            "Voice Sender",
+            "Please send this as voice",
+            {},
+        )
+
+        draft = DraftService.create_draft(
+            db=test_db,
+            message_id=message.id,
+            user_id=test_user.id,
+            twin_id=twin.id,
+            content="Thanks for reaching out.",
+            confidence_score=0.88,
+            confidence_label="High",
+            moderation_passed=True,
+            moderation_flags=[],
+        )
+        return draft
+
+    def test_task_returns_disabled_when_feature_flag_off(self, test_db, test_user, monkeypatch):
+        _bind_task_engine_to_test_db(monkeypatch, test_db)
+        draft = self._seed_draft(test_db, test_user)
+
+        class _Settings:
+            feature_voice_clone = False
+            database_url = "sqlite://"
+
+        monkeypatch.setattr(voice_synthesis, "get_settings", lambda: _Settings())
+
+        result = voice_synthesis.synthesize_voice.run(
+            draft_id=draft.id,
+            user_id=test_user.id,
+            text="hello",
+        )
+
+        assert result["status"] == "disabled"
+
+    def test_task_uses_profile_provider_and_updates_draft(self, test_db, test_user, monkeypatch):
+        _bind_task_engine_to_test_db(monkeypatch, test_db)
+        draft = self._seed_draft(test_db, test_user)
+
+        profile = test_db.query(IdentityProfile).filter(IdentityProfile.user_id == test_user.id).first()
+        if not profile:
+            profile = IdentityProfile(user_id=test_user.id)
+            test_db.add(profile)
+        profile.voice_provider = "mock"
+        profile.voice_model_id = "model-local-001"
+        test_db.commit()
+
+        class _Settings:
+            feature_voice_clone = True
+            database_url = "sqlite://"
+            voice_provider = "mock"
+            voice_default_model_id = ""
+
+        monkeypatch.setattr(voice_synthesis, "get_settings", lambda: _Settings())
+
+        result = voice_synthesis.synthesize_voice.run(
+            draft_id=draft.id,
+            user_id=test_user.id,
+            text="hello",
+        )
+
+        assert result["status"] == "success"
+        assert result["provider"] == "mock"
+        assert result["voice_status"] == "generated"
+        assert result["audio_url"].startswith("mock://voice/")
+
+        db = sessionmaker(bind=test_db.get_bind())()
+        try:
+            stored = db.query(Draft).filter(Draft.id == draft.id).first()
+            assert stored.voice_status == "generated"
+            assert stored.voice_provider == "mock"
+            assert stored.voice_model_id == "model-local-001"
+            assert stored.voice_audio_url is not None
+        finally:
+            db.close()
+
+    def test_task_returns_failed_when_provider_unconfigured(self, test_db, test_user, monkeypatch):
+        _bind_task_engine_to_test_db(monkeypatch, test_db)
+        draft = self._seed_draft(test_db, test_user)
+
+        profile = test_db.query(IdentityProfile).filter(IdentityProfile.user_id == test_user.id).first()
+        if not profile:
+            profile = IdentityProfile(user_id=test_user.id)
+            test_db.add(profile)
+        profile.voice_provider = "elevenlabs"
+        profile.voice_model_id = "elv-model"
+        test_db.commit()
+
+        class _Settings:
+            feature_voice_clone = True
+            database_url = "sqlite://"
+            voice_provider = "elevenlabs"
+            voice_default_model_id = ""
+            elevenlabs_api_key = ""
+
+        monkeypatch.setattr(voice_synthesis, "get_settings", lambda: _Settings())
+
+        result = voice_synthesis.synthesize_voice.run(
+            draft_id=draft.id,
+            user_id=test_user.id,
+            text="hello",
+        )
+
+        assert result["status"] == "failed"
+        assert result["provider"] == "elevenlabs"
+        assert "not configured" in (result["error"] or "")


### PR DESCRIPTION
## Summary
Phase 6 PR A foundation for voice clone support.

## Changes
- Add voice provider abstraction and registry (`mock`, `elevenlabs` adapter foundation)
- Add voice-related backend config/env settings
- Add voice metadata fields on `identity_profiles` and `drafts`
- Add migration `002_phase6_voice_foundation`
- Refactor `voice_synthesis` task to provider-based orchestration and DB status updates
- Add focused tests for provider registry and synthesis task behavior

## Validation
- `python -m pytest tests/test_phase6_voice_foundation.py -q --tb=short`
- `python -m pytest tests/ -q --tb=short`

## Notes
This PR provides the base platform for subsequent voice consent/enrollment and delivery endpoints.