### PR TITLE
feat: Phase 6 PR B voice consent and enrollment APIs

### DIFF
--- a/src/backend/app/routers/identity.py
+++ b/src/backend/app/routers/identity.py
@@ -18,6 +18,10 @@ from app.schemas.identity import (
     IdentityProfileResponse,
     UpdateIdentityRequest,
     IdentityConfidenceResponse,
+    VoiceConsentRequest,
+    VoiceConsentResponse,
+    VoiceEnrollmentRequest,
+    VoiceEnrollmentResponse,
     RESPONSE_LENGTH_MAP,
 )
 from typing import List
@@ -254,3 +258,114 @@ async def get_identity_confidence(
     """
     result = IdentityService.get_confidence_score(db, current_user.id)
     return IdentityConfidenceResponse(**result)
+
+
+# ── Voice Clone (Phase 6 PR B) ──────────────────────────────────────────────
+
+@router.get("/voice/consent", response_model=VoiceConsentResponse)
+async def get_voice_consent(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get current voice clone consent state."""
+    consent = IdentityService.get_voice_consent(db, current_user.id)
+    if not consent:
+        return VoiceConsentResponse(
+            consent_type="voice_clone",
+            granted=False,
+            granted_at=None,
+            expires_at=None,
+        )
+
+    return VoiceConsentResponse(
+        consent_type=consent.consent_type,
+        granted=consent.granted,
+        granted_at=consent.granted_at.isoformat() if consent.granted_at else None,
+        expires_at=consent.expires_at.isoformat() if consent.expires_at else None,
+    )
+
+
+@router.post("/voice/consent", response_model=VoiceConsentResponse)
+async def set_voice_consent(
+    request: VoiceConsentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Grant or revoke consent for voice cloning."""
+    consent = IdentityService.set_voice_consent(db, current_user.id, request.granted)
+    if not request.granted:
+        # Revoke enrolled voice data when consent is revoked.
+        IdentityService.clear_voice_profile(db, current_user.id)
+
+    return VoiceConsentResponse(
+        consent_type=consent.consent_type,
+        granted=consent.granted,
+        granted_at=consent.granted_at.isoformat() if consent.granted_at else None,
+        expires_at=consent.expires_at.isoformat() if consent.expires_at else None,
+    )
+
+
+@router.get("/voice/profile", response_model=VoiceEnrollmentResponse)
+async def get_voice_profile(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get current voice enrollment metadata and consent state."""
+    profile = IdentityService.get_identity_profile(db, current_user.id)
+    consent_granted = IdentityService.is_voice_consent_granted(db, current_user.id)
+    enrolled = bool(profile and profile.voice_model_id)
+
+    return VoiceEnrollmentResponse(
+        enrolled=enrolled,
+        voice_provider=profile.voice_provider if profile else None,
+        voice_model_id=profile.voice_model_id if profile else None,
+        voice_sample_url=profile.voice_sample_url if profile else None,
+        consent_granted=consent_granted,
+    )
+
+
+@router.post("/voice/enroll", response_model=VoiceEnrollmentResponse)
+async def enroll_voice_profile(
+    request: VoiceEnrollmentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Enroll or update a voice profile after explicit voice clone consent."""
+    if not IdentityService.is_voice_consent_granted(db, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Voice clone consent is required before enrollment",
+        )
+
+    profile = IdentityService.enroll_voice_profile(
+        db,
+        user_id=current_user.id,
+        voice_provider=request.voice_provider,
+        voice_model_id=request.voice_model_id,
+        voice_sample_url=request.voice_sample_url,
+    )
+
+    return VoiceEnrollmentResponse(
+        enrolled=bool(profile.voice_model_id),
+        voice_provider=profile.voice_provider,
+        voice_model_id=profile.voice_model_id,
+        voice_sample_url=profile.voice_sample_url,
+        consent_granted=True,
+    )
+
+
+@router.delete("/voice/profile", response_model=VoiceEnrollmentResponse)
+async def clear_voice_profile(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Clear voice enrollment metadata while leaving consent unchanged."""
+    profile = IdentityService.clear_voice_profile(db, current_user.id)
+    consent_granted = IdentityService.is_voice_consent_granted(db, current_user.id)
+    return VoiceEnrollmentResponse(
+        enrolled=False,
+        voice_provider=profile.voice_provider,
+        voice_model_id=profile.voice_model_id,
+        voice_sample_url=profile.voice_sample_url,
+        consent_granted=consent_granted,
+    )

--- a/src/backend/app/schemas/identity.py
+++ b/src/backend/app/schemas/identity.py
@@ -114,3 +114,44 @@ class IdentityConfidenceResponse(BaseModel):
     fields_complete: int   # number of profile fields filled
     total_fields: int      # total profile fields scored
     message: str           # human-readable status
+
+
+class VoiceConsentRequest(BaseModel):
+    """Grant or revoke voice clone consent."""
+
+    granted: bool
+
+
+class VoiceConsentResponse(BaseModel):
+    """Voice consent state for the current user."""
+
+    consent_type: str
+    granted: bool
+    granted_at: Optional[str] = None
+    expires_at: Optional[str] = None
+
+
+class VoiceEnrollmentRequest(BaseModel):
+    """Voice profile enrollment payload."""
+
+    voice_provider: str = "mock"
+    voice_model_id: Optional[str] = None
+    voice_sample_url: Optional[str] = None
+
+    @field_validator("voice_provider")
+    @classmethod
+    def validate_voice_provider(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in {"mock", "elevenlabs"}:
+            raise ValueError("voice_provider must be 'mock' or 'elevenlabs'")
+        return normalized
+
+
+class VoiceEnrollmentResponse(BaseModel):
+    """Voice profile enrollment status."""
+
+    enrolled: bool
+    voice_provider: Optional[str] = None
+    voice_model_id: Optional[str] = None
+    voice_sample_url: Optional[str] = None
+    consent_granted: bool

--- a/src/backend/app/services/identity.py
+++ b/src/backend/app/services/identity.py
@@ -2,9 +2,11 @@
 Identity profile management service
 """
 
+from datetime import datetime, UTC
+
 from sqlalchemy.orm import Session
 from sqlalchemy import and_
-from app.models import IdentityProfile, Topic, Twin
+from app.models import IdentityProfile, Topic, Twin, Consent
 
 
 class IdentityService:
@@ -255,3 +257,75 @@ class IdentityService:
             "total_fields": TOTAL_FIELDS,
             "message": message,
         }
+
+    @staticmethod
+    def get_voice_consent(db: Session, user_id: str) -> Consent | None:
+        """Return voice clone consent row if present."""
+        return db.query(Consent).filter(
+            Consent.user_id == user_id,
+            Consent.consent_type == "voice_clone",
+        ).first()
+
+    @staticmethod
+    def set_voice_consent(db: Session, user_id: str, granted: bool) -> Consent:
+        """Create or update voice clone consent state."""
+        consent = IdentityService.get_voice_consent(db, user_id)
+        if not consent:
+            consent = Consent(user_id=user_id, consent_type="voice_clone")
+
+        consent.granted = granted
+        consent.granted_at = datetime.now(UTC).replace(tzinfo=None) if granted else None
+        if not granted:
+            consent.expires_at = None
+
+        db.add(consent)
+        db.commit()
+        db.refresh(consent)
+        return consent
+
+    @staticmethod
+    def is_voice_consent_granted(db: Session, user_id: str) -> bool:
+        """Check whether voice clone consent is currently granted."""
+        consent = IdentityService.get_voice_consent(db, user_id)
+        if not consent or not consent.granted:
+            return False
+        if consent.expires_at and consent.expires_at <= datetime.now(UTC).replace(tzinfo=None):
+            return False
+        return True
+
+    @staticmethod
+    def enroll_voice_profile(
+        db: Session,
+        user_id: str,
+        voice_provider: str,
+        voice_model_id: str | None,
+        voice_sample_url: str | None,
+    ) -> IdentityProfile:
+        """Persist voice profile metadata in identity profile."""
+        profile = IdentityService.get_identity_profile(db, user_id)
+        if not profile:
+            profile = IdentityProfile(user_id=user_id)
+
+        profile.voice_provider = voice_provider
+        profile.voice_model_id = voice_model_id
+        profile.voice_sample_url = voice_sample_url
+
+        db.add(profile)
+        db.commit()
+        db.refresh(profile)
+        return profile
+
+    @staticmethod
+    def clear_voice_profile(db: Session, user_id: str) -> IdentityProfile:
+        """Remove enrolled voice metadata for the user."""
+        profile = IdentityService.get_identity_profile(db, user_id)
+        if not profile:
+            profile = IdentityProfile(user_id=user_id)
+
+        profile.voice_model_id = None
+        profile.voice_sample_url = None
+
+        db.add(profile)
+        db.commit()
+        db.refresh(profile)
+        return profile

--- a/src/backend/tests/test_identity.py
+++ b/src/backend/tests/test_identity.py
@@ -286,3 +286,107 @@ class TestConfidence:
         """Unauthenticated request returns 403 (middleware behaviour)."""
         response = client.get("/v1/identity/confidence")
         assert response.status_code == 403
+
+
+# ── Voice Clone (Phase 6 PR B) ─────────────────────────────────────────────
+
+class TestVoiceCloneEnrollment:
+    def test_voice_consent_defaults_to_false(self, client, auth_headers):
+        response = client.get("/v1/identity/voice/consent", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["consent_type"] == "voice_clone"
+        assert data["granted"] is False
+
+    def test_grant_and_revoke_voice_consent(self, client, auth_headers):
+        grant = client.post(
+            "/v1/identity/voice/consent",
+            json={"granted": True},
+            headers=auth_headers,
+        )
+        assert grant.status_code == 200
+        assert grant.json()["granted"] is True
+        assert grant.json()["granted_at"] is not None
+
+        revoke = client.post(
+            "/v1/identity/voice/consent",
+            json={"granted": False},
+            headers=auth_headers,
+        )
+        assert revoke.status_code == 200
+        assert revoke.json()["granted"] is False
+
+    def test_enroll_requires_consent(self, client, auth_headers):
+        response = client.post(
+            "/v1/identity/voice/enroll",
+            json={
+                "voice_provider": "mock",
+                "voice_model_id": "voice-001",
+                "voice_sample_url": "https://example.com/sample.wav",
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 409
+
+    def test_enroll_after_consent_and_fetch_profile(self, client, auth_headers):
+        client.post(
+            "/v1/identity/voice/consent",
+            json={"granted": True},
+            headers=auth_headers,
+        )
+
+        enroll = client.post(
+            "/v1/identity/voice/enroll",
+            json={
+                "voice_provider": "mock",
+                "voice_model_id": "voice-001",
+                "voice_sample_url": "https://example.com/sample.wav",
+            },
+            headers=auth_headers,
+        )
+        assert enroll.status_code == 200
+        data = enroll.json()
+        assert data["enrolled"] is True
+        assert data["voice_provider"] == "mock"
+        assert data["voice_model_id"] == "voice-001"
+        assert data["consent_granted"] is True
+
+        profile = client.get("/v1/identity/voice/profile", headers=auth_headers)
+        assert profile.status_code == 200
+        profile_data = profile.json()
+        assert profile_data["enrolled"] is True
+        assert profile_data["voice_model_id"] == "voice-001"
+
+    def test_clear_voice_profile(self, client, auth_headers):
+        client.post("/v1/identity/voice/consent", json={"granted": True}, headers=auth_headers)
+        client.post(
+            "/v1/identity/voice/enroll",
+            json={"voice_provider": "mock", "voice_model_id": "voice-123"},
+            headers=auth_headers,
+        )
+
+        clear = client.delete("/v1/identity/voice/profile", headers=auth_headers)
+        assert clear.status_code == 200
+        assert clear.json()["enrolled"] is False
+        assert clear.json()["voice_model_id"] is None
+
+    def test_revoke_consent_clears_voice_profile(self, client, auth_headers):
+        client.post("/v1/identity/voice/consent", json={"granted": True}, headers=auth_headers)
+        client.post(
+            "/v1/identity/voice/enroll",
+            json={"voice_provider": "mock", "voice_model_id": "voice-xyz"},
+            headers=auth_headers,
+        )
+
+        client.post("/v1/identity/voice/consent", json={"granted": False}, headers=auth_headers)
+        profile = client.get("/v1/identity/voice/profile", headers=auth_headers)
+        assert profile.status_code == 200
+        assert profile.json()["enrolled"] is False
+        assert profile.json()["voice_model_id"] is None
+
+    def test_voice_endpoints_require_auth(self, client):
+        assert client.get("/v1/identity/voice/consent").status_code == 403
+        assert client.post("/v1/identity/voice/consent", json={"granted": True}).status_code == 403
+        assert client.post("/v1/identity/voice/enroll", json={"voice_provider": "mock"}).status_code == 403
+        assert client.get("/v1/identity/voice/profile").status_code == 403
+        assert client.delete("/v1/identity/voice/profile").status_code == 403


### PR DESCRIPTION
## Summary
Phase 6 PR B adds voice consent and enrollment lifecycle endpoints on top of PR A.

## Changes
- Add voice consent/enrollment schemas
- Add identity service methods for:
  - voice consent state get/set
  - consent-granted check
  - voice profile enroll/clear
- Add identity endpoints:
  - `GET /v1/identity/voice/consent`
  - `POST /v1/identity/voice/consent`
  - `GET /v1/identity/voice/profile`
  - `POST /v1/identity/voice/enroll`
  - `DELETE /v1/identity/voice/profile`
- Enforce consent before enrollment
- Revoke flow clears enrolled voice profile metadata
- Add endpoint tests for voice consent/enrollment lifecycle

## Validation
- `python -m pytest tests/test_identity.py -q --tb=short`
- `python -m pytest tests/ -q --tb=short`

## Notes
Stacked PR: base is PR A branch.