### PR TITLE
feat: Phase 6 PR C draft voice generation and status endpoints

### DIFF
--- a/src/backend/app/routers/drafts.py
+++ b/src/backend/app/routers/drafts.py
@@ -9,7 +9,16 @@ from app.database import get_db
 from app.middleware.auth import get_current_user
 from app.models import User
 from app.services import DraftService
-from app.schemas import DraftResponse, DraftApprovalRequest
+from app.services.identity import IdentityService
+from app.schemas import (
+    DraftResponse,
+    DraftApprovalRequest,
+    DraftVoiceGenerateRequest,
+    DraftVoiceGenerateResponse,
+    DraftVoiceStatusResponse,
+)
+from app.config import get_settings
+from app.tasks.voice_synthesis import synthesize_voice
 from typing import List
 
 router = APIRouter(tags=["drafts"])
@@ -137,4 +146,95 @@ async def process_draft_action(
         )
     
     return DraftResponse.model_validate(updated_draft)
+
+
+@router.post("/{draft_id}/voice/generate", response_model=DraftVoiceGenerateResponse)
+async def generate_draft_voice(
+    draft_id: str,
+    request: DraftVoiceGenerateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Queue voice synthesis for an approved/edited draft."""
+    settings = get_settings()
+    if not settings.feature_voice_clone:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Voice clone feature is disabled",
+        )
+
+    draft = DraftService.get_draft(db, draft_id)
+    if not draft:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Draft not found")
+
+    if draft.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unauthorized: Draft belongs to different user",
+        )
+
+    if draft.status not in ("approved", "edited"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Draft must be approved or edited before voice generation",
+        )
+
+    if not IdentityService.is_voice_consent_granted(db, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Voice clone consent is required before generation",
+        )
+
+    text = draft.edited_content or draft.content
+
+    updated = DraftService.set_voice_status(
+        db,
+        draft_id=draft.id,
+        voice_status="queued",
+        voice_audio_url=None,
+        voice_provider=None,
+        voice_model_id=request.voice_model_id,
+        voice_error=None,
+    )
+
+    task_result = synthesize_voice.delay(
+        draft_id=draft.id,
+        user_id=current_user.id,
+        text=text,
+        voice_profile_id=request.voice_model_id,
+    )
+
+    return DraftVoiceGenerateResponse(
+        draft_id=draft.id,
+        queued=True,
+        voice_status=updated.voice_status,
+        task_id=str(task_result.id) if task_result else None,
+    )
+
+
+@router.get("/{draft_id}/voice", response_model=DraftVoiceStatusResponse)
+async def get_draft_voice_status(
+    draft_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get voice synthesis status and delivery URL for a draft."""
+    draft = DraftService.get_draft(db, draft_id)
+    if not draft:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Draft not found")
+
+    if draft.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unauthorized: Draft belongs to different user",
+        )
+
+    return DraftVoiceStatusResponse(
+        draft_id=draft.id,
+        voice_status=draft.voice_status,
+        voice_audio_url=draft.voice_audio_url,
+        voice_provider=draft.voice_provider,
+        voice_model_id=draft.voice_model_id,
+        voice_error=draft.voice_error,
+    )
 

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -19,6 +19,9 @@ from app.schemas.twin import (
     MessageResponse,
     DraftResponse,
     DraftApprovalRequest,
+    DraftVoiceGenerateRequest,
+    DraftVoiceGenerateResponse,
+    DraftVoiceStatusResponse,
 )
 
 from app.schemas.identity import (
@@ -54,6 +57,9 @@ __all__ = [
     "MessageResponse",
     "DraftResponse",
     "DraftApprovalRequest",
+    "DraftVoiceGenerateRequest",
+    "DraftVoiceGenerateResponse",
+    "DraftVoiceStatusResponse",
     # Identity
     "OnboardingRequest",
     "OnboardingResponse",

--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -85,6 +85,11 @@ class DraftResponse(BaseModel):
     estimated_output_tokens: Optional[int]
     estimated_total_tokens: Optional[int]
     estimated_cost_usd: Optional[float]
+    voice_status: Optional[str]
+    voice_audio_url: Optional[str]
+    voice_provider: Optional[str]
+    voice_model_id: Optional[str]
+    voice_error: Optional[str]
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -94,6 +99,32 @@ class DraftApprovalRequest(BaseModel):
     """Request to approve, edit, or reject a draft"""
     action: str  # approve, reject, edit, skip
     edited_content: Optional[str] = None  # Required if action == "edit"
+
+
+class DraftVoiceGenerateRequest(BaseModel):
+    """Request payload to queue voice synthesis for a draft."""
+
+    voice_model_id: Optional[str] = None
+
+
+class DraftVoiceGenerateResponse(BaseModel):
+    """Queue response for draft voice synthesis."""
+
+    draft_id: str
+    queued: bool
+    voice_status: str
+    task_id: Optional[str] = None
+
+
+class DraftVoiceStatusResponse(BaseModel):
+    """Voice synthesis status for a draft."""
+
+    draft_id: str
+    voice_status: str
+    voice_audio_url: Optional[str] = None
+    voice_provider: Optional[str] = None
+    voice_model_id: Optional[str] = None
+    voice_error: Optional[str] = None
 
 
 

--- a/src/backend/app/services/draft.py
+++ b/src/backend/app/services/draft.py
@@ -280,3 +280,28 @@ class DraftService:
             "rejected": rejected,
             "sent": sent,
         }
+
+    @staticmethod
+    def set_voice_status(
+        db: Session,
+        draft_id: str,
+        voice_status: str,
+        voice_audio_url: str = None,
+        voice_provider: str = None,
+        voice_model_id: str = None,
+        voice_error: str = None,
+    ) -> Draft:
+        """Update voice synthesis fields on a draft."""
+        draft = DraftService.get_draft(db, draft_id)
+        if not draft:
+            return None
+
+        draft.voice_status = voice_status
+        draft.voice_audio_url = voice_audio_url
+        draft.voice_provider = voice_provider
+        draft.voice_model_id = voice_model_id
+        draft.voice_error = voice_error
+
+        db.commit()
+        db.refresh(draft)
+        return draft

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -3,6 +3,7 @@ Integration tests for backend API endpoints
 """
 
 import pytest
+from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 
 from app.models import AuditLog, Draft
@@ -444,6 +445,140 @@ class TestDraftEndpoints:
         response = client.get("/v1/drafts/pending")
         
         assert response.status_code == 403
+
+    @patch("app.routers.drafts.get_settings")
+    @patch("app.routers.drafts.synthesize_voice")
+    def test_generate_voice_queues_task_for_approved_draft(
+        self,
+        mock_synthesize_voice,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Approved draft with consent should queue voice synthesis task."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+        DraftService.approve_draft(test_db, draft.id, current_user.id)
+
+        # Grant voice consent
+        client.post("/v1/identity/voice/consent", headers=auth_headers, json={"granted": True})
+
+        mock_settings.return_value.feature_voice_clone = True
+        mock_task = MagicMock()
+        mock_task.id = "task-voice-123"
+        mock_synthesize_voice.delay.return_value = mock_task
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/voice/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["draft_id"] == draft.id
+        assert data["queued"] is True
+        assert data["voice_status"] == "queued"
+        assert data["task_id"] == "task-voice-123"
+
+    @patch("app.routers.drafts.get_settings")
+    def test_generate_voice_requires_consent(
+        self,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Voice generation should fail when consent is missing."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+        DraftService.approve_draft(test_db, draft.id, current_user.id)
+
+        mock_settings.return_value.feature_voice_clone = True
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/voice/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 409
+
+    @patch("app.routers.drafts.get_settings")
+    def test_generate_voice_requires_approved_or_edited_status(
+        self,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Pending drafts cannot be queued for voice synthesis."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+
+        client.post("/v1/identity/voice/consent", headers=auth_headers, json={"granted": True})
+        mock_settings.return_value.feature_voice_clone = True
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/voice/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 409
+
+    @patch("app.routers.drafts.get_settings")
+    def test_generate_voice_disabled_feature_returns_503(
+        self,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Feature flag off should return service unavailable."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+        DraftService.approve_draft(test_db, draft.id, current_user.id)
+
+        client.post("/v1/identity/voice/consent", headers=auth_headers, json={"granted": True})
+        mock_settings.return_value.feature_voice_clone = False
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/voice/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 503
+
+    def test_get_draft_voice_status(self, client, auth_headers, test_db, test_user_data):
+        """Voice status endpoint should return persisted voice metadata."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+
+        DraftService.set_voice_status(
+            test_db,
+            draft.id,
+            voice_status="generated",
+            voice_audio_url="mock://voice/test.mp3",
+            voice_provider="mock",
+            voice_model_id="voice-test-1",
+            voice_error=None,
+        )
+
+        response = client.get(f"/v1/drafts/{draft.id}/voice", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["voice_status"] == "generated"
+        assert data["voice_audio_url"] == "mock://voice/test.mp3"
+        assert data["voice_provider"] == "mock"
+        assert data["voice_model_id"] == "voice-test-1"
 
 
 class TestPushTokenEndpoints:


### PR DESCRIPTION
## Summary
Phase 6 PR C adds draft-level voice generation queueing and status retrieval on top of PR B.

## Changes
- Add draft voice request/response schemas
- Extend draft response to include voice synthesis fields
- Add draft service helper for voice status updates
- Add drafts endpoints:
  - `POST /v1/drafts/{draft_id}/voice/generate`
  - `GET /v1/drafts/{draft_id}/voice`
- Enforce guards for:
  - feature flag enabled
  - draft ownership
  - allowed draft status (`approved` or `edited`)
  - voice consent granted
- Queue voice synthesis task and return task id
- Add endpoint tests for queueing, gates, and status retrieval

## Validation
- `python -m pytest tests/test_endpoints.py -q --tb=short`
- `python -m pytest tests/ -q --tb=short`

## Notes
Stacked PR: base is PR B branch.