### PR TITLE
Add Phase 7 plan with security hardening and release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.7.1] - 2026-04-28
+
+### Added
+- Phase 6 voice provider foundation and registry.
+- Voice consent and enrollment APIs.
+- Draft voice generation queue and status APIs.
+- Phase 7 avatar execution plan document.
+- Optional Gmail webhook shared-secret protection via X-Webhook-Token.
+
+### Changed
+- OAuth state for channel callbacks is signed and purpose-bound.
+- LiteLLM import is lazy-loaded in twin engine to avoid startup warning noise.
+- Twin stats schema now explicitly allows model_breakdown field name in Pydantic v2.
+- Instagram webhook ingestion caches page-to-user lookups per request.
+
+### Security
+- Production startup now enforces strong JWT secret policy.
+- Production-only auth rate limiting introduced for signup and login endpoints.
+
+### Validation
+- Backend test suite passes fully after these changes.

--- a/docs/06-implementation/PHASE_7_AVATAR_EXECUTION_PLAN.md
+++ b/docs/06-implementation/PHASE_7_AVATAR_EXECUTION_PLAN.md
@@ -1,0 +1,131 @@
+# SELPH Phase 7 Avatar Clone Execution Plan
+
+Date: 2026-04-28
+Owner: Engineering
+Status: Ready to Execute
+
+## Objective
+
+Ship Phase 7 Avatar Clone as a safe, reversible extension of the existing text and voice pipeline, with clear quality gates before production rollout.
+
+## Scope
+
+In scope:
+- Avatar consent and enrollment flow
+- Avatar provider abstraction (default self-hosted, optional managed provider)
+- Draft-to-video generation workflow
+- Transparent mode verification overlay
+- Audit and moderation checks before delivery
+- Test coverage for core happy and failure paths
+
+Out of scope:
+- Real-time avatar calls
+- Multi-language lip-sync optimization
+- Enterprise admin controls
+
+## Architecture Additions
+
+Backend additions:
+- app/avatar/base.py
+- app/avatar/registry.py
+- app/avatar/providers/linly.py
+- app/avatar/providers/heygen.py
+- app/tasks/avatar_synthesis.py
+- app/routers/avatar.py
+- app/schemas/avatar.py
+- app/services/avatar.py
+
+Data model additions:
+- identity_profiles:
+  - avatar_provider
+  - avatar_model_id
+  - avatar_sample_url
+  - avatar_consent
+  - avatar_consent_at
+- drafts:
+  - avatar_status
+  - avatar_video_url
+  - avatar_provider
+  - avatar_model_id
+  - avatar_error
+
+## Rollout Sequence
+
+1. Foundation and schema migration
+- Add avatar provider interface and provider registry.
+- Add DB migration for identity and draft avatar fields.
+- Add feature flag: feature_avatar_clone.
+
+2. Consent and enrollment endpoints
+- Add endpoints to grant/revoke avatar consent.
+- Add endpoint to enroll avatar profile after consent.
+- Add endpoint to clear avatar profile.
+
+3. Draft video generation endpoints
+- Add POST endpoint to queue avatar generation for approved or edited drafts.
+- Add GET endpoint for avatar generation status.
+- Enforce ownership, consent, and draft status checks.
+
+4. Safety and transparency controls
+- Apply moderation gate before video synthesis.
+- Apply transparent verification overlay metadata.
+- Persist full audit events for queue, generation, and failure.
+
+5. Provider and failure hardening
+- Implement deterministic mock path for tests.
+- Add retry and error normalization for provider failures.
+- Ensure idempotent status transitions for repeated queue requests.
+
+## Acceptance Criteria
+
+- User can enable avatar consent and enroll an avatar profile.
+- Avatar generation can be queued for approved and edited drafts.
+- Status endpoint returns queued, processing, completed, or failed.
+- Generated video URL is persisted and returned to user.
+- Transparent mode metadata is applied and auditable.
+- Full backend tests pass with no warnings.
+
+## Test Plan
+
+Unit tests:
+- Provider registry selection and unknown-provider errors.
+- Avatar task behavior for disabled feature, consent missing, provider unavailable.
+
+Integration tests:
+- Consent and enrollment endpoints.
+- Queue and status endpoints.
+- Ownership and invalid-state rejection paths.
+
+Regression tests:
+- Existing auth, identity, draft, and channels tests remain green.
+
+## Risk Register
+
+1. Provider instability
+- Mitigation: provider abstraction, retries, graceful fail state.
+
+2. Unsafe impersonation misuse
+- Mitigation: explicit consent, transparent mode watermark, audit trail.
+
+3. Latency spikes on generation
+- Mitigation: queue-based async pipeline and status polling.
+
+4. Data retention concerns for media
+- Mitigation: storage lifecycle policy and explicit delete flow.
+
+## Execution Checklist
+
+- [ ] Migration created and reversible
+- [ ] Avatar provider interface and registry implemented
+- [ ] Consent and enrollment endpoints implemented
+- [ ] Draft queue and status endpoints implemented
+- [ ] Avatar synthesis task implemented
+- [ ] Audit and safety checks implemented
+- [ ] Test suite passes with no warnings
+- [ ] Feature flag rollout documented
+
+## Branching and Delivery
+
+Branch: feature/phase7-planning
+Next implementation branch: feature/phase7-avatar-pr-a
+Delivery model: stacked PRs (A foundation, B consent/enrollment, C generation/status)

--- a/docs/06-implementation/RELEASE_READINESS_CHECKLIST.md
+++ b/docs/06-implementation/RELEASE_READINESS_CHECKLIST.md
@@ -1,0 +1,55 @@
+# Release Readiness Checklist
+
+Date: 2026-04-28
+Target Release: 0.7.1
+Branch for release candidate work: feature/phase7-planning
+
+## 1) Code and Branch State
+
+- [ ] main branch is clean and synced with origin/main
+- [ ] release candidate branch rebased onto latest main
+- [ ] no unreviewed direct commits on main
+
+## 2) Backend Validation
+
+- [x] full backend tests pass
+- [x] channel integration tests pass
+- [x] no warning regression in backend test runs
+
+## 3) Security Validation
+
+- [x] signed OAuth state validation for channel callbacks
+- [x] production JWT secret enforcement guard active
+- [x] production auth rate limit configured
+- [x] optional Gmail webhook shared-secret check available
+
+## 4) Performance Validation
+
+- [x] Instagram webhook path avoids repeated page-to-user lookups per request
+- [ ] p95 API latency report captured from staging
+- [ ] queue throughput snapshot captured from worker metrics
+
+## 5) Configuration and Secrets
+
+- [ ] JWT_SECRET_KEY set to strong 32+ character value in production
+- [ ] GOOGLE_WEBHOOK_SECRET set if Gmail webhook secret protection is required
+- [ ] AUTH_RATE_LIMIT_PER_MINUTE tuned for expected traffic profile
+- [ ] ENFORCE_PRODUCTION_JWT_SECRET=true in production env
+
+## 6) Release Tag and Notes
+
+Recommended tag after merge to main:
+- v0.7.1
+
+Commands:
+- git checkout main
+- git pull --ff-only origin main
+- git tag -a v0.7.1 -m "Release 0.7.1: Voice phase complete, security/perf hardening"
+- git push origin v0.7.1
+
+## 7) Deployment Gate
+
+- [ ] migration plan confirmed (if any DB changes included)
+- [ ] rollback plan documented
+- [ ] smoke tests pass post-deploy
+- [ ] monitoring and alerts verified for first 60 minutes

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -73,6 +73,8 @@ GOOGLE_OAUTH_CLIENT_ID=your_client_id.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET=your_client_secret
 GOOGLE_OAUTH_REDIRECT_URI=http://localhost:8000/v1/channels/gmail/callback
 GOOGLE_PUBSUB_TOPIC=projects/your-project-id/topics/gmail-push
+# Optional shared secret checked via X-Webhook-Token on /v1/channels/gmail/webhook
+GOOGLE_WEBHOOK_SECRET=
 
 # Voice Clone (Phase 6 foundation)
 # Use mock for local/testing. Set to elevenlabs when integrating provider APIs.
@@ -100,6 +102,10 @@ SERVICE_NAME=selph-backend
 # ============================================================================
 LOG_LEVEL=INFO
 ENABLE_METRICS=true
+# In production, block startup if JWT secret is default/weak
+ENFORCE_PRODUCTION_JWT_SECRET=true
+# Production-only auth endpoint request cap per IP per minute
+AUTH_RATE_LIMIT_PER_MINUTE=20
 
 # ============================================================================
 # PHASE FEATURE FLAGS (controlled rollout)

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -70,6 +70,7 @@ class Settings(BaseSettings):
     google_oauth_client_secret: str = ""
     google_oauth_redirect_uri: str = ""  # e.g. https://api.selph.ai/v1/channels/gmail/callback
     google_pubsub_topic: str = ""  # e.g. projects/selph/topics/gmail-push
+    google_webhook_secret: str = ""  # Optional shared secret for /channels/gmail/webhook
 
     # Voice Clone (Phase 6)
     voice_provider: str = "mock"  # mock | elevenlabs
@@ -79,6 +80,10 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = "INFO"
     enable_metrics: bool = True
+
+    # Security hardening
+    auth_rate_limit_per_minute: int = 20
+    enforce_production_jwt_secret: bool = True
     
     # Feature Flags
     feature_twin_briefing: bool = False

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -25,6 +25,11 @@ async def lifespan(app: FastAPI):
     print("🚀 SELPH Backend Starting...")
     print(f"   Environment: {settings.environment}")
     print(f"   API Version: {settings.api_v1_str}")
+
+    if settings.environment.lower() == "production" and settings.enforce_production_jwt_secret:
+        # Block unsafe default/weak JWT secrets in production.
+        if settings.jwt_secret_key == "dev-secret-key-change-in-production" or len(settings.jwt_secret_key) < 32:
+            raise RuntimeError("Insecure JWT secret for production. Set JWT_SECRET_KEY to a strong 32+ char value.")
     
     yield
     

--- a/src/backend/app/routers/auth.py
+++ b/src/backend/app/routers/auth.py
@@ -3,20 +3,49 @@ Authentication endpoints
 /v1/auth/*
 """
 
-from fastapi import APIRouter, HTTPException, status, Depends
+import time
+from collections import defaultdict, deque
+
+from fastapi import APIRouter, HTTPException, status, Depends, Request
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.middleware.auth import get_current_user
+from app.config import get_settings
 from app.schemas import SignupRequest, LoginRequest, TokenResponse, AuthResponse, UserResponse, PushTokenRequest, PushTokenResponse
 from app.services import AuthService
 from app.models import User
 
 router = APIRouter(tags=["auth"])
+_auth_requests: dict[str, deque[float]] = defaultdict(deque)
+
+
+def _enforce_auth_rate_limit(route_name: str, client_ip: str) -> None:
+    settings = get_settings()
+    if settings.environment.lower() != "production":
+        return
+
+    limit = max(1, settings.auth_rate_limit_per_minute)
+    now = time.time()
+    window_start = now - 60
+    bucket_key = f"{route_name}:{client_ip}"
+    bucket = _auth_requests[bucket_key]
+
+    while bucket and bucket[0] < window_start:
+        bucket.popleft()
+
+    if len(bucket) >= limit:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many authentication attempts. Please wait and try again.",
+        )
+
+    bucket.append(now)
 
 
 @router.post("/signup", response_model=AuthResponse, status_code=status.HTTP_201_CREATED)
 async def signup(
     request: SignupRequest,
+    client_request: Request,
     db: Session = Depends(get_db),
 ):
     """
@@ -24,6 +53,8 @@ async def signup(
     
     Returns: User data and JWT tokens (access + refresh)
     """
+    _enforce_auth_rate_limit("signup", getattr(client_request.client, "host", "unknown"))
+
     try:
         user = AuthService.signup(db, request)
     except ValueError as e:
@@ -48,6 +79,7 @@ async def signup(
 @router.post("/login", response_model=AuthResponse)
 async def login(
     request: LoginRequest,
+    client_request: Request,
     db: Session = Depends(get_db),
 ):
     """
@@ -55,6 +87,8 @@ async def login(
 
     Returns: User data and JWT tokens (access + refresh)
     """
+    _enforce_auth_rate_limit("login", getattr(client_request.client, "host", "unknown"))
+
     try:
         user = AuthService.login(db, request)
     except ValueError as e:

--- a/src/backend/app/routers/channels.py
+++ b/src/backend/app/routers/channels.py
@@ -12,6 +12,7 @@ Provides:
 """
 
 import json
+import hmac
 import logging
 from datetime import timedelta
 
@@ -234,9 +235,16 @@ async def instagram_webhook_receive(
         return WebhookAckResponse(received=True, queued=0)
 
     queued = 0
+    page_user_cache: dict[str, str | None] = {}
     for nm in normalized_messages:
         page_id = nm.channel_metadata.get("page_id")
-        user_id = ChannelService.find_user_by_instagram_page(db, page_id) if page_id else None
+        if not page_id:
+            user_id = None
+        elif page_id in page_user_cache:
+            user_id = page_user_cache[page_id]
+        else:
+            user_id = ChannelService.find_user_by_instagram_page(db, page_id)
+            page_user_cache[page_id] = user_id
 
         if not user_id:
             logger.warning(
@@ -351,6 +359,15 @@ async def gmail_webhook_receive(
     Google sends a POST with a base64-encoded notification when new emails arrive.
     We decode it, fetch the new message via Gmail History API, and enqueue processing.
     """
+    settings = get_settings()
+    if settings.google_webhook_secret:
+        received_secret = request.headers.get("X-Webhook-Token", "")
+        if not hmac.compare_digest(received_secret, settings.google_webhook_secret):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Invalid Gmail webhook token",
+            )
+
     try:
         payload = await request.json()
     except Exception:

--- a/src/backend/tests/test_phase5_channels.py
+++ b/src/backend/tests/test_phase5_channels.py
@@ -869,6 +869,27 @@ class TestGmailWebhookEndpoint:
         assert resp.status_code == 200
         assert resp.json()["queued"] == 0
 
+    def test_webhook_rejects_invalid_shared_secret_when_configured(self, unauth_client):
+        with patch("app.routers.channels.get_settings") as mock_settings:
+            mock_settings.return_value.google_webhook_secret = "expected-secret"
+            resp = unauth_client.post(
+                "/v1/channels/gmail/webhook",
+                json=self._make_pubsub_body("user@gmail.com"),
+                headers={"X-Webhook-Token": "wrong-secret"},
+            )
+        assert resp.status_code == 403
+
+    def test_webhook_accepts_shared_secret_when_configured(self, unauth_client):
+        with patch("app.routers.channels.get_settings") as mock_settings:
+            mock_settings.return_value.google_webhook_secret = "expected-secret"
+            resp = unauth_client.post(
+                "/v1/channels/gmail/webhook",
+                json=self._make_pubsub_body("nobody@example.com"),
+                headers={"X-Webhook-Token": "expected-secret"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["queued"] == 0
+
     def test_webhook_known_user_enqueues_messages(self, unauth_client, test_db, db_user):
         ChannelService.upsert_credential(
             test_db, db_user.id, "gmail",


### PR DESCRIPTION
## Summary
This PR delivers the next implementation slice one by one:
- Adds a concrete Phase 7 Avatar Clone execution plan
- Hardens backend security around auth and webhooks
- Adds release artifacts for changelog and deployment readiness

## What Changed
- Added Phase 7 planning doc:
  - `docs/06-implementation/PHASE_7_AVATAR_EXECUTION_PLAN.md`
- Added release readiness docs:
  - `CHANGELOG.md`
  - `docs/06-implementation/RELEASE_READINESS_CHECKLIST.md`
- Security hardening:
  - Production JWT secret enforcement during app startup
  - Production-only auth endpoint rate limiting (`signup`/`login`)
  - Optional Gmail webhook shared-secret validation (`X-Webhook-Token`)
  - Added related config/env settings
- Performance improvement:
  - Request-scope cache for Instagram webhook page-to-user lookup
- Test updates:
  - Added Gmail webhook shared-secret coverage in `test_phase5_channels.py`

## Validation
- `tests/test_phase5_channels.py`: 80 passed
- Full backend suite: 224 passed

## Notes
- Auth rate limiting is intentionally enabled only in production.
- Gmail webhook token check is optional and active only when `GOOGLE_WEBHOOK_SECRET` is configured.