### PR TITLE
Add Phase 7 PR A avatar foundation

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -82,6 +82,12 @@ VOICE_PROVIDER=mock
 ELEVENLABS_API_KEY=
 VOICE_DEFAULT_MODEL_ID=
 
+# Avatar Clone (Phase 7 foundation)
+# Use mock for local/testing. Set to heygen when integrating provider APIs.
+AVATAR_PROVIDER=mock
+HEYGEN_API_KEY=
+AVATAR_DEFAULT_MODEL_ID=
+
 # ============================================================================
 # APPLICATION SETTINGS
 # ============================================================================

--- a/src/backend/app/avatar/__init__.py
+++ b/src/backend/app/avatar/__init__.py
@@ -1,0 +1,11 @@
+"""Avatar synthesis provider abstraction and registry."""
+
+from app.avatar.base import AvatarProvider, AvatarSynthesisRequest, AvatarSynthesisResult
+from app.avatar.registry import get_avatar_provider
+
+__all__ = [
+    "AvatarProvider",
+    "AvatarSynthesisRequest",
+    "AvatarSynthesisResult",
+    "get_avatar_provider",
+]

--- a/src/backend/app/avatar/base.py
+++ b/src/backend/app/avatar/base.py
@@ -1,0 +1,38 @@
+"""Base interfaces for avatar synthesis providers."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class AvatarSynthesisRequest:
+    """Normalized request payload for avatar generation."""
+
+    text: str
+    avatar_model_id: str | None = None
+    voice_audio_url: str | None = None
+    user_id: str | None = None
+    draft_id: str | None = None
+
+
+@dataclass
+class AvatarSynthesisResult:
+    """Normalized avatar generation response for task orchestration."""
+
+    ok: bool
+    provider: str
+    video_url: str | None = None
+    error: str | None = None
+
+
+class AvatarProvider(ABC):
+    """Abstract provider contract for avatar synthesis backends."""
+
+    @property
+    @abstractmethod
+    def provider_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def synthesize(self, request: AvatarSynthesisRequest) -> AvatarSynthesisResult:
+        raise NotImplementedError

--- a/src/backend/app/avatar/providers/heygen.py
+++ b/src/backend/app/avatar/providers/heygen.py
@@ -1,0 +1,44 @@
+"""HeyGen provider adapter for future production avatar cloning."""
+
+import logging
+
+from app.avatar.base import AvatarProvider, AvatarSynthesisRequest, AvatarSynthesisResult
+
+logger = logging.getLogger(__name__)
+
+
+class HeyGenAvatarProvider(AvatarProvider):
+    """Phase 7 foundation adapter.
+
+    This validates config and request prerequisites and returns a structured
+    not-configured/not-implemented response for PR A foundation.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key or ""
+
+    @property
+    def provider_name(self) -> str:
+        return "heygen"
+
+    def synthesize(self, request: AvatarSynthesisRequest) -> AvatarSynthesisResult:
+        if not self._api_key:
+            return AvatarSynthesisResult(
+                ok=False,
+                provider=self.provider_name,
+                error="HEYGEN_API_KEY is not configured",
+            )
+
+        if not request.avatar_model_id:
+            return AvatarSynthesisResult(
+                ok=False,
+                provider=self.provider_name,
+                error="avatar_model_id is required for HeyGen synthesis",
+            )
+
+        logger.info("HeyGen adapter foundation called for draft=%s", request.draft_id)
+        return AvatarSynthesisResult(
+            ok=False,
+            provider=self.provider_name,
+            error="HeyGen synthesis implementation is planned in Phase 7 PR B",
+        )

--- a/src/backend/app/avatar/providers/mock.py
+++ b/src/backend/app/avatar/providers/mock.py
@@ -1,0 +1,19 @@
+"""Deterministic mock avatar provider for local development and tests."""
+
+from app.avatar.base import AvatarProvider, AvatarSynthesisRequest, AvatarSynthesisResult
+
+
+class MockAvatarProvider(AvatarProvider):
+    """Returns a deterministic mock video URL with no external calls."""
+
+    @property
+    def provider_name(self) -> str:
+        return "mock"
+
+    def synthesize(self, request: AvatarSynthesisRequest) -> AvatarSynthesisResult:
+        draft_id = request.draft_id or "unknown"
+        return AvatarSynthesisResult(
+            ok=True,
+            provider=self.provider_name,
+            video_url=f"mock://avatar/{draft_id}.mp4",
+        )

--- a/src/backend/app/avatar/registry.py
+++ b/src/backend/app/avatar/registry.py
@@ -1,0 +1,19 @@
+"""Provider registry for avatar synthesis backends."""
+
+from app.avatar.base import AvatarProvider
+from app.avatar.providers.mock import MockAvatarProvider
+from app.avatar.providers.heygen import HeyGenAvatarProvider
+from app.config import get_settings
+
+
+def get_avatar_provider(provider_name: str | None = None) -> AvatarProvider:
+    """Return a concrete avatar provider instance from config or explicit name."""
+    settings = get_settings()
+    selected = (provider_name or settings.avatar_provider or "mock").strip().lower()
+
+    if selected == "mock":
+        return MockAvatarProvider()
+    if selected == "heygen":
+        return HeyGenAvatarProvider(api_key=settings.heygen_api_key)
+
+    raise ValueError(f"Unsupported avatar provider '{selected}'")

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -76,6 +76,11 @@ class Settings(BaseSettings):
     voice_provider: str = "mock"  # mock | elevenlabs
     elevenlabs_api_key: str = ""
     voice_default_model_id: str = ""
+
+    # Avatar Clone (Phase 7)
+    avatar_provider: str = "mock"  # mock | heygen
+    heygen_api_key: str = ""
+    avatar_default_model_id: str = ""
     
     # Logging
     log_level: str = "INFO"

--- a/src/backend/app/models/draft.py
+++ b/src/backend/app/models/draft.py
@@ -48,6 +48,13 @@ class Draft(BaseModel):
     voice_provider = Column(String, nullable=True)
     voice_model_id = Column(String, nullable=True)
     voice_error = Column(Text, nullable=True)
+
+    # Avatar synthesis (Phase 7)
+    avatar_status = Column(String, default="not_requested", nullable=False)
+    avatar_video_url = Column(Text, nullable=True)
+    avatar_provider = Column(String, nullable=True)
+    avatar_model_id = Column(String, nullable=True)
+    avatar_error = Column(Text, nullable=True)
     
     # Status
     status = Column(String, default="pending_approval", nullable=False)  # pending_approval, approved, edited, rejected, sent

--- a/src/backend/app/models/identity_profile.py
+++ b/src/backend/app/models/identity_profile.py
@@ -29,6 +29,9 @@ class IdentityProfile(BaseModel):
     voice_model_id = Column(String, nullable=True)
     voice_provider = Column(String, default="mock", nullable=False)
     voice_sample_url = Column(Text, nullable=True)
+    avatar_model_id = Column(String, nullable=True)
+    avatar_provider = Column(String, default="mock", nullable=False)
+    avatar_sample_url = Column(Text, nullable=True)
     
     # Relationships
     user = relationship("User", back_populates="identity_profile")

--- a/src/backend/app/tasks/avatar_generation.py
+++ b/src/backend/app/tasks/avatar_generation.py
@@ -1,16 +1,22 @@
-"""
-Avatar generation tasks
-Phase 0: Stub for phase 7 implementation
-Future: Integrate RunwayML or D-ID for avatar synthesis
+"""Avatar generation tasks
+Phase 7 PR A: provider abstraction + DB orchestration foundation
 """
 
-from celery import shared_task
 import logging
+
+from celery import shared_task
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.avatar.base import AvatarSynthesisRequest
+from app.avatar.registry import get_avatar_provider
+from app.config import get_settings
+from app.models import Draft, IdentityProfile
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(bind=True, max_retries=2)
+@shared_task(bind=True, max_retries=2, queue="avatar_generation")
 def generate_avatar(
     self,
     draft_id: str,
@@ -19,51 +25,72 @@ def generate_avatar(
     avatar_style_id: str = None,
     voice_audio_url: str = None,
 ):
-    """
-    Generate avatar video for a draft response
-    
-    Phase 0: Placeholder
-    Phase 7: Full avatar generation implementation with:
-    - Avatar style management (appearance, clothing, etc.)
-    - RunwayML or D-ID API integration
-    - Lip-sync with voice audio
-    - Video file storage in Cloudflare R2
-    - Quality validation
-    
-    Args:
-        draft_id: Draft to generate avatar for
-        user_id: Owner of the twin
-        text: Text for avatar to deliver
-        avatar_style_id: Avatar appearance profile ID
-        voice_audio_url: URL of synthesized voice audio
-    
-    Returns:
-        dict with video_url (Phase 7)
-    """
-    logger.info(f"[PHASE 7 STUB] Avatar generation task queued for draft {draft_id}")
-    
-    return {
-        "status": "phase_7_placeholder",
-        "draft_id": draft_id,
-        "message": "Avatar generation coming in Phase 7",
-    }
+    """Generate avatar video for a draft response."""
+    settings = get_settings()
+    if not settings.feature_avatar_clone:
+        logger.info("Avatar clone feature disabled; skipping draft %s", draft_id)
+        return {
+            "status": "disabled",
+            "draft_id": draft_id,
+            "reason": "FEATURE_AVATAR_CLONE is disabled",
+        }
+
+    engine = create_engine(settings.database_url)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    try:
+        draft = db.query(Draft).filter(Draft.id == draft_id, Draft.user_id == user_id).first()
+        if not draft:
+            return {"status": "error", "draft_id": draft_id, "reason": "Draft not found"}
+
+        profile = db.query(IdentityProfile).filter(IdentityProfile.user_id == user_id).first()
+        provider_name = profile.avatar_provider if profile and profile.avatar_provider else settings.avatar_provider
+        model_id = avatar_style_id or (profile.avatar_model_id if profile else None) or settings.avatar_default_model_id
+
+        provider = get_avatar_provider(provider_name)
+        result = provider.synthesize(
+            AvatarSynthesisRequest(
+                text=text,
+                avatar_model_id=model_id,
+                voice_audio_url=voice_audio_url,
+                user_id=user_id,
+                draft_id=draft_id,
+            )
+        )
+
+        draft.avatar_provider = result.provider
+        draft.avatar_model_id = model_id
+
+        if result.ok:
+            draft.avatar_status = "generated"
+            draft.avatar_video_url = result.video_url
+            draft.avatar_error = None
+            status = "success"
+        else:
+            draft.avatar_status = "failed"
+            draft.avatar_error = result.error
+            status = "failed"
+
+        db.commit()
+
+        return {
+            "status": status,
+            "draft_id": draft_id,
+            "provider": result.provider,
+            "avatar_status": draft.avatar_status,
+            "video_url": draft.avatar_video_url,
+            "error": draft.avatar_error,
+        }
+    finally:
+        db.close()
 
 
 @shared_task
 def batch_generate_avatars(draft_ids: list, user_id: str):
-    """
-    Generate avatars for multiple drafts in batch
-    
-    Args:
-        draft_ids: List of draft IDs
-        user_id: Owner of the twin
-    
-    Returns:
-        dict with processing status
-    """
-    logger.info(f"[PHASE 7 STUB] Batch avatar generation queued for {len(draft_ids)} drafts")
-    
+    """Generate avatars for multiple drafts in batch."""
+    logger.info("[PHASE 7 FOUNDATION] Batch avatar generation queued for %d drafts", len(draft_ids))
+
     return {
-        "status": "phase_7_placeholder",
+        "status": "phase_7_foundation",
         "drafts_queued": len(draft_ids),
     }

--- a/src/backend/migrations/versions/003_phase7_avatar_foundation.py
+++ b/src/backend/migrations/versions/003_phase7_avatar_foundation.py
@@ -1,0 +1,43 @@
+"""Phase 7 avatar foundation fields
+
+Revision ID: 003_phase7_avatar_foundation
+Revises: 002_phase6_voice_foundation
+Create Date: 2026-04-28 00:30:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "003_phase7_avatar_foundation"
+down_revision = "002_phase6_voice_foundation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # identity_profiles
+    op.add_column("identity_profiles", sa.Column("avatar_model_id", sa.String(), nullable=True))
+    op.add_column("identity_profiles", sa.Column("avatar_provider", sa.String(), nullable=False, server_default="mock"))
+    op.add_column("identity_profiles", sa.Column("avatar_sample_url", sa.Text(), nullable=True))
+
+    # drafts
+    op.add_column("drafts", sa.Column("avatar_status", sa.String(), nullable=False, server_default="not_requested"))
+    op.add_column("drafts", sa.Column("avatar_video_url", sa.Text(), nullable=True))
+    op.add_column("drafts", sa.Column("avatar_provider", sa.String(), nullable=True))
+    op.add_column("drafts", sa.Column("avatar_model_id", sa.String(), nullable=True))
+    op.add_column("drafts", sa.Column("avatar_error", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("drafts", "avatar_error")
+    op.drop_column("drafts", "avatar_model_id")
+    op.drop_column("drafts", "avatar_provider")
+    op.drop_column("drafts", "avatar_video_url")
+    op.drop_column("drafts", "avatar_status")
+
+    op.drop_column("identity_profiles", "avatar_sample_url")
+    op.drop_column("identity_profiles", "avatar_provider")
+    op.drop_column("identity_profiles", "avatar_model_id")

--- a/src/backend/tests/test_phase7_avatar_foundation.py
+++ b/src/backend/tests/test_phase7_avatar_foundation.py
@@ -1,0 +1,148 @@
+"""Phase 7 PR A tests: avatar provider abstraction and task foundation."""
+
+from sqlalchemy.orm import sessionmaker
+
+from app.avatar.registry import get_avatar_provider
+from app.models import Draft, IdentityProfile, Message, Twin
+from app.services import DraftService, MessageService
+from app.tasks import avatar_generation
+
+
+def _bind_task_engine_to_test_db(monkeypatch, test_db):
+    engine = test_db.get_bind()
+    monkeypatch.setattr(avatar_generation, "create_engine", lambda _url: engine)
+
+
+class TestAvatarProviderRegistry:
+    def test_get_default_provider_returns_mock(self):
+        provider = get_avatar_provider("mock")
+        assert provider.provider_name == "mock"
+
+    def test_unknown_provider_raises(self):
+        try:
+            get_avatar_provider("unknown-provider")
+            assert False, "Expected ValueError for unknown provider"
+        except ValueError as exc:
+            assert "Unsupported avatar provider" in str(exc)
+
+
+class TestAvatarGenerationTaskFoundation:
+    def _seed_draft(self, test_db, test_user):
+        twin = test_db.query(Twin).filter(Twin.user_id == test_user.id).first()
+        if not twin:
+            twin = Twin(user_id=test_user.id, status="active")
+            test_db.add(twin)
+            test_db.flush()
+
+        message = MessageService.create_message(
+            test_db,
+            test_user.id,
+            "gmail",
+            "sender-avatar-1",
+            "Avatar Sender",
+            "Please send this as avatar video",
+            {},
+        )
+
+        draft = DraftService.create_draft(
+            db=test_db,
+            message_id=message.id,
+            user_id=test_user.id,
+            twin_id=twin.id,
+            content="Thanks for reaching out.",
+            confidence_score=0.88,
+            confidence_label="High",
+            moderation_passed=True,
+            moderation_flags=[],
+        )
+        return draft
+
+    def test_task_returns_disabled_when_feature_flag_off(self, test_db, test_user, monkeypatch):
+        _bind_task_engine_to_test_db(monkeypatch, test_db)
+        draft = self._seed_draft(test_db, test_user)
+
+        class _Settings:
+            feature_avatar_clone = False
+            database_url = "sqlite://"
+
+        monkeypatch.setattr(avatar_generation, "get_settings", lambda: _Settings())
+
+        result = avatar_generation.generate_avatar.run(
+            draft_id=draft.id,
+            user_id=test_user.id,
+            text="hello",
+        )
+
+        assert result["status"] == "disabled"
+
+    def test_task_uses_profile_provider_and_updates_draft(self, test_db, test_user, monkeypatch):
+        _bind_task_engine_to_test_db(monkeypatch, test_db)
+        draft = self._seed_draft(test_db, test_user)
+
+        profile = test_db.query(IdentityProfile).filter(IdentityProfile.user_id == test_user.id).first()
+        if not profile:
+            profile = IdentityProfile(user_id=test_user.id)
+            test_db.add(profile)
+        profile.avatar_provider = "mock"
+        profile.avatar_model_id = "avatar-local-001"
+        test_db.commit()
+
+        class _Settings:
+            feature_avatar_clone = True
+            database_url = "sqlite://"
+            avatar_provider = "mock"
+            avatar_default_model_id = ""
+
+        monkeypatch.setattr(avatar_generation, "get_settings", lambda: _Settings())
+
+        result = avatar_generation.generate_avatar.run(
+            draft_id=draft.id,
+            user_id=test_user.id,
+            text="hello",
+        )
+
+        assert result["status"] == "success"
+        assert result["provider"] == "mock"
+        assert result["avatar_status"] == "generated"
+        assert result["video_url"].startswith("mock://avatar/")
+
+        db = sessionmaker(bind=test_db.get_bind())()
+        try:
+            stored = db.query(Draft).filter(Draft.id == draft.id).first()
+            assert stored.avatar_status == "generated"
+            assert stored.avatar_provider == "mock"
+            assert stored.avatar_model_id == "avatar-local-001"
+            assert stored.avatar_video_url is not None
+        finally:
+            db.close()
+
+    def test_task_returns_failed_when_provider_unconfigured(self, test_db, test_user, monkeypatch):
+        _bind_task_engine_to_test_db(monkeypatch, test_db)
+        draft = self._seed_draft(test_db, test_user)
+
+        profile = test_db.query(IdentityProfile).filter(IdentityProfile.user_id == test_user.id).first()
+        if not profile:
+            profile = IdentityProfile(user_id=test_user.id)
+            test_db.add(profile)
+        profile.avatar_provider = "heygen"
+        profile.avatar_model_id = "heygen-model"
+        test_db.commit()
+
+        class _Settings:
+            feature_avatar_clone = True
+            database_url = "sqlite://"
+            avatar_provider = "heygen"
+            avatar_default_model_id = ""
+            heygen_api_key = ""
+
+        monkeypatch.setattr(avatar_generation, "get_settings", lambda: _Settings())
+
+        result = avatar_generation.generate_avatar.run(
+            draft_id=draft.id,
+            user_id=test_user.id,
+            text="hello",
+        )
+
+        assert result["status"] == "failed"
+        assert result["provider"] == "heygen"
+        assert "not configured" in (result["error"] or "")


### PR DESCRIPTION
## Summary
Implements Phase 7 PR A foundation for avatar clone support, aligned with the existing Phase 6 voice architecture.

## What Changed
- Added avatar provider abstraction and registry:
  - `app/avatar/base.py`
  - `app/avatar/registry.py`
  - `app/avatar/providers/mock.py`
  - `app/avatar/providers/heygen.py`
- Replaced Phase 0 avatar task stub with provider-based orchestration:
  - `app/tasks/avatar_generation.py`
- Added avatar foundation DB fields in models:
  - `IdentityProfile`: `avatar_model_id`, `avatar_provider`, `avatar_sample_url`
  - `Draft`: `avatar_status`, `avatar_video_url`, `avatar_provider`, `avatar_model_id`, `avatar_error`
- Added migration:
  - `003_phase7_avatar_foundation`
- Added config/env support:
  - `avatar_provider`, `heygen_api_key`, `avatar_default_model_id`
- Added test coverage:
  - `tests/test_phase7_avatar_foundation.py`

## Validation
- New tests: `tests/test_phase7_avatar_foundation.py` -> 5 passed
- Full backend suite: 229 passed

## Notes
- This PR is intentionally foundation-only.
- Provider integrations are structured to return clear not-configured/not-implemented responses until follow-up PRs implement full synthesis APIs.