### PR TITLE
Add Phase 7 PR B avatar consent and enrollment APIs

### DIFF
--- a/src/backend/app/routers/identity.py
+++ b/src/backend/app/routers/identity.py
@@ -22,6 +22,10 @@ from app.schemas.identity import (
     VoiceConsentResponse,
     VoiceEnrollmentRequest,
     VoiceEnrollmentResponse,
+    AvatarConsentRequest,
+    AvatarConsentResponse,
+    AvatarEnrollmentRequest,
+    AvatarEnrollmentResponse,
     RESPONSE_LENGTH_MAP,
 )
 from typing import List
@@ -367,5 +371,116 @@ async def clear_voice_profile(
         voice_provider=profile.voice_provider,
         voice_model_id=profile.voice_model_id,
         voice_sample_url=profile.voice_sample_url,
+        consent_granted=consent_granted,
+    )
+
+
+# ── Avatar Clone (Phase 7 PR B) ─────────────────────────────────────────────
+
+@router.get("/avatar/consent", response_model=AvatarConsentResponse)
+async def get_avatar_consent(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get current avatar clone consent state."""
+    consent = IdentityService.get_avatar_consent(db, current_user.id)
+    if not consent:
+        return AvatarConsentResponse(
+            consent_type="avatar_clone",
+            granted=False,
+            granted_at=None,
+            expires_at=None,
+        )
+
+    return AvatarConsentResponse(
+        consent_type=consent.consent_type,
+        granted=consent.granted,
+        granted_at=consent.granted_at.isoformat() if consent.granted_at else None,
+        expires_at=consent.expires_at.isoformat() if consent.expires_at else None,
+    )
+
+
+@router.post("/avatar/consent", response_model=AvatarConsentResponse)
+async def set_avatar_consent(
+    request: AvatarConsentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Grant or revoke consent for avatar cloning."""
+    consent = IdentityService.set_avatar_consent(db, current_user.id, request.granted)
+    if not request.granted:
+        # Revoke enrolled avatar data when consent is revoked.
+        IdentityService.clear_avatar_profile(db, current_user.id)
+
+    return AvatarConsentResponse(
+        consent_type=consent.consent_type,
+        granted=consent.granted,
+        granted_at=consent.granted_at.isoformat() if consent.granted_at else None,
+        expires_at=consent.expires_at.isoformat() if consent.expires_at else None,
+    )
+
+
+@router.get("/avatar/profile", response_model=AvatarEnrollmentResponse)
+async def get_avatar_profile(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get current avatar enrollment metadata and consent state."""
+    profile = IdentityService.get_identity_profile(db, current_user.id)
+    consent_granted = IdentityService.is_avatar_consent_granted(db, current_user.id)
+    enrolled = bool(profile and profile.avatar_model_id)
+
+    return AvatarEnrollmentResponse(
+        enrolled=enrolled,
+        avatar_provider=profile.avatar_provider if profile else None,
+        avatar_model_id=profile.avatar_model_id if profile else None,
+        avatar_sample_url=profile.avatar_sample_url if profile else None,
+        consent_granted=consent_granted,
+    )
+
+
+@router.post("/avatar/enroll", response_model=AvatarEnrollmentResponse)
+async def enroll_avatar_profile(
+    request: AvatarEnrollmentRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Enroll or update an avatar profile after explicit avatar clone consent."""
+    if not IdentityService.is_avatar_consent_granted(db, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Avatar clone consent is required before enrollment",
+        )
+
+    profile = IdentityService.enroll_avatar_profile(
+        db,
+        user_id=current_user.id,
+        avatar_provider=request.avatar_provider,
+        avatar_model_id=request.avatar_model_id,
+        avatar_sample_url=request.avatar_sample_url,
+    )
+
+    return AvatarEnrollmentResponse(
+        enrolled=bool(profile.avatar_model_id),
+        avatar_provider=profile.avatar_provider,
+        avatar_model_id=profile.avatar_model_id,
+        avatar_sample_url=profile.avatar_sample_url,
+        consent_granted=True,
+    )
+
+
+@router.delete("/avatar/profile", response_model=AvatarEnrollmentResponse)
+async def clear_avatar_profile(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Clear avatar enrollment metadata while leaving consent unchanged."""
+    profile = IdentityService.clear_avatar_profile(db, current_user.id)
+    consent_granted = IdentityService.is_avatar_consent_granted(db, current_user.id)
+    return AvatarEnrollmentResponse(
+        enrolled=False,
+        avatar_provider=profile.avatar_provider,
+        avatar_model_id=profile.avatar_model_id,
+        avatar_sample_url=profile.avatar_sample_url,
         consent_granted=consent_granted,
     )

--- a/src/backend/app/schemas/identity.py
+++ b/src/backend/app/schemas/identity.py
@@ -155,3 +155,44 @@ class VoiceEnrollmentResponse(BaseModel):
     voice_model_id: Optional[str] = None
     voice_sample_url: Optional[str] = None
     consent_granted: bool
+
+
+class AvatarConsentRequest(BaseModel):
+    """Grant or revoke avatar clone consent."""
+
+    granted: bool
+
+
+class AvatarConsentResponse(BaseModel):
+    """Avatar consent state for the current user."""
+
+    consent_type: str
+    granted: bool
+    granted_at: Optional[str] = None
+    expires_at: Optional[str] = None
+
+
+class AvatarEnrollmentRequest(BaseModel):
+    """Avatar profile enrollment payload."""
+
+    avatar_provider: str = "mock"
+    avatar_model_id: Optional[str] = None
+    avatar_sample_url: Optional[str] = None
+
+    @field_validator("avatar_provider")
+    @classmethod
+    def validate_avatar_provider(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in {"mock", "heygen"}:
+            raise ValueError("avatar_provider must be 'mock' or 'heygen'")
+        return normalized
+
+
+class AvatarEnrollmentResponse(BaseModel):
+    """Avatar profile enrollment status."""
+
+    enrolled: bool
+    avatar_provider: Optional[str] = None
+    avatar_model_id: Optional[str] = None
+    avatar_sample_url: Optional[str] = None
+    consent_granted: bool

--- a/src/backend/app/services/identity.py
+++ b/src/backend/app/services/identity.py
@@ -329,3 +329,75 @@ class IdentityService:
         db.commit()
         db.refresh(profile)
         return profile
+
+    @staticmethod
+    def get_avatar_consent(db: Session, user_id: str) -> Consent | None:
+        """Return avatar clone consent row if present."""
+        return db.query(Consent).filter(
+            Consent.user_id == user_id,
+            Consent.consent_type == "avatar_clone",
+        ).first()
+
+    @staticmethod
+    def set_avatar_consent(db: Session, user_id: str, granted: bool) -> Consent:
+        """Create or update avatar clone consent state."""
+        consent = IdentityService.get_avatar_consent(db, user_id)
+        if not consent:
+            consent = Consent(user_id=user_id, consent_type="avatar_clone")
+
+        consent.granted = granted
+        consent.granted_at = datetime.now(UTC).replace(tzinfo=None) if granted else None
+        if not granted:
+            consent.expires_at = None
+
+        db.add(consent)
+        db.commit()
+        db.refresh(consent)
+        return consent
+
+    @staticmethod
+    def is_avatar_consent_granted(db: Session, user_id: str) -> bool:
+        """Check whether avatar clone consent is currently granted."""
+        consent = IdentityService.get_avatar_consent(db, user_id)
+        if not consent or not consent.granted:
+            return False
+        if consent.expires_at and consent.expires_at <= datetime.now(UTC).replace(tzinfo=None):
+            return False
+        return True
+
+    @staticmethod
+    def enroll_avatar_profile(
+        db: Session,
+        user_id: str,
+        avatar_provider: str,
+        avatar_model_id: str | None,
+        avatar_sample_url: str | None,
+    ) -> IdentityProfile:
+        """Persist avatar profile metadata in identity profile."""
+        profile = IdentityService.get_identity_profile(db, user_id)
+        if not profile:
+            profile = IdentityProfile(user_id=user_id)
+
+        profile.avatar_provider = avatar_provider
+        profile.avatar_model_id = avatar_model_id
+        profile.avatar_sample_url = avatar_sample_url
+
+        db.add(profile)
+        db.commit()
+        db.refresh(profile)
+        return profile
+
+    @staticmethod
+    def clear_avatar_profile(db: Session, user_id: str) -> IdentityProfile:
+        """Remove enrolled avatar metadata for the user."""
+        profile = IdentityService.get_identity_profile(db, user_id)
+        if not profile:
+            profile = IdentityProfile(user_id=user_id)
+
+        profile.avatar_model_id = None
+        profile.avatar_sample_url = None
+
+        db.add(profile)
+        db.commit()
+        db.refresh(profile)
+        return profile

--- a/src/backend/tests/test_identity.py
+++ b/src/backend/tests/test_identity.py
@@ -390,3 +390,107 @@ class TestVoiceCloneEnrollment:
         assert client.post("/v1/identity/voice/enroll", json={"voice_provider": "mock"}).status_code == 403
         assert client.get("/v1/identity/voice/profile").status_code == 403
         assert client.delete("/v1/identity/voice/profile").status_code == 403
+
+
+# ── Avatar Clone (Phase 7 PR B) ─────────────────────────────────────────────
+
+class TestAvatarCloneEnrollment:
+    def test_avatar_consent_defaults_to_false(self, client, auth_headers):
+        response = client.get("/v1/identity/avatar/consent", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["consent_type"] == "avatar_clone"
+        assert data["granted"] is False
+
+    def test_grant_and_revoke_avatar_consent(self, client, auth_headers):
+        grant = client.post(
+            "/v1/identity/avatar/consent",
+            json={"granted": True},
+            headers=auth_headers,
+        )
+        assert grant.status_code == 200
+        assert grant.json()["granted"] is True
+        assert grant.json()["granted_at"] is not None
+
+        revoke = client.post(
+            "/v1/identity/avatar/consent",
+            json={"granted": False},
+            headers=auth_headers,
+        )
+        assert revoke.status_code == 200
+        assert revoke.json()["granted"] is False
+
+    def test_enroll_requires_consent(self, client, auth_headers):
+        response = client.post(
+            "/v1/identity/avatar/enroll",
+            json={
+                "avatar_provider": "mock",
+                "avatar_model_id": "avatar-001",
+                "avatar_sample_url": "https://example.com/sample.mp4",
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 409
+
+    def test_enroll_after_consent_and_fetch_profile(self, client, auth_headers):
+        client.post(
+            "/v1/identity/avatar/consent",
+            json={"granted": True},
+            headers=auth_headers,
+        )
+
+        enroll = client.post(
+            "/v1/identity/avatar/enroll",
+            json={
+                "avatar_provider": "mock",
+                "avatar_model_id": "avatar-001",
+                "avatar_sample_url": "https://example.com/sample.mp4",
+            },
+            headers=auth_headers,
+        )
+        assert enroll.status_code == 200
+        data = enroll.json()
+        assert data["enrolled"] is True
+        assert data["avatar_provider"] == "mock"
+        assert data["avatar_model_id"] == "avatar-001"
+        assert data["consent_granted"] is True
+
+        profile = client.get("/v1/identity/avatar/profile", headers=auth_headers)
+        assert profile.status_code == 200
+        profile_data = profile.json()
+        assert profile_data["enrolled"] is True
+        assert profile_data["avatar_model_id"] == "avatar-001"
+
+    def test_clear_avatar_profile(self, client, auth_headers):
+        client.post("/v1/identity/avatar/consent", json={"granted": True}, headers=auth_headers)
+        client.post(
+            "/v1/identity/avatar/enroll",
+            json={"avatar_provider": "mock", "avatar_model_id": "avatar-123"},
+            headers=auth_headers,
+        )
+
+        clear = client.delete("/v1/identity/avatar/profile", headers=auth_headers)
+        assert clear.status_code == 200
+        assert clear.json()["enrolled"] is False
+        assert clear.json()["avatar_model_id"] is None
+
+    def test_revoke_consent_clears_avatar_profile(self, client, auth_headers):
+        client.post("/v1/identity/avatar/consent", json={"granted": True}, headers=auth_headers)
+        client.post(
+            "/v1/identity/avatar/enroll",
+            json={"avatar_provider": "mock", "avatar_model_id": "avatar-xyz"},
+            headers=auth_headers,
+        )
+
+        client.post("/v1/identity/avatar/consent", json={"granted": False}, headers=auth_headers)
+        profile = client.get("/v1/identity/avatar/profile", headers=auth_headers)
+        assert profile.status_code == 200
+        assert profile.json()["enrolled"] is False
+        assert profile.json()["avatar_model_id"] is None
+
+    def test_avatar_endpoints_require_auth(self, client):
+        assert client.get("/v1/identity/avatar/consent").status_code == 403
+        assert client.post("/v1/identity/avatar/consent", json={"granted": True}).status_code == 403
+        assert client.post("/v1/identity/avatar/enroll", json={"avatar_provider": "mock"}).status_code == 403
+        assert client.get("/v1/identity/avatar/profile").status_code == 403
+        assert client.delete("/v1/identity/avatar/profile").status_code == 403


### PR DESCRIPTION
## Summary
Implements Phase 7 PR B on top of PR A by adding avatar consent lifecycle and enrollment APIs under identity.

## What Changed
- Added avatar consent schemas:
  - `AvatarConsentRequest`
  - `AvatarConsentResponse`
- Added avatar enrollment schemas:
  - `AvatarEnrollmentRequest`
  - `AvatarEnrollmentResponse`
- Added identity service methods:
  - `get_avatar_consent`
  - `set_avatar_consent`
  - `is_avatar_consent_granted`
  - `enroll_avatar_profile`
  - `clear_avatar_profile`
- Added identity router endpoints:
  - `GET /v1/identity/avatar/consent`
  - `POST /v1/identity/avatar/consent`
  - `GET /v1/identity/avatar/profile`
  - `POST /v1/identity/avatar/enroll`
  - `DELETE /v1/identity/avatar/profile`
- Added endpoint tests in `tests/test_identity.py` for:
  - default consent state
  - grant/revoke
  - consent-required enrollment
  - profile fetch, clear, and revoke behavior
  - auth requirements

## Validation
- `tests/test_identity.py`: 40 passed
- Full backend suite: 236 passed

## Notes
- Follows the same operational and safety pattern already used by voice clone consent/enrollment.
- This PR is API and service-layer only; draft avatar generation endpoints are planned for PR C.