### PR TITLE
Add Phase 7 PR C draft avatar generate and status APIs

### DIFF
--- a/src/backend/app/routers/drafts.py
+++ b/src/backend/app/routers/drafts.py
@@ -16,9 +16,13 @@ from app.schemas import (
     DraftVoiceGenerateRequest,
     DraftVoiceGenerateResponse,
     DraftVoiceStatusResponse,
+    DraftAvatarGenerateRequest,
+    DraftAvatarGenerateResponse,
+    DraftAvatarStatusResponse,
 )
 from app.config import get_settings
 from app.tasks.voice_synthesis import synthesize_voice
+from app.tasks.avatar_generation import generate_avatar
 from typing import List
 
 router = APIRouter(tags=["drafts"])
@@ -236,5 +240,97 @@ async def get_draft_voice_status(
         voice_provider=draft.voice_provider,
         voice_model_id=draft.voice_model_id,
         voice_error=draft.voice_error,
+    )
+
+
+@router.post("/{draft_id}/avatar/generate", response_model=DraftAvatarGenerateResponse)
+async def generate_draft_avatar(
+    draft_id: str,
+    request: DraftAvatarGenerateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Queue avatar generation for an approved/edited draft."""
+    settings = get_settings()
+    if not settings.feature_avatar_clone:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Avatar clone feature is disabled",
+        )
+
+    draft = DraftService.get_draft(db, draft_id)
+    if not draft:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Draft not found")
+
+    if draft.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unauthorized: Draft belongs to different user",
+        )
+
+    if draft.status not in ("approved", "edited"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Draft must be approved or edited before avatar generation",
+        )
+
+    if not IdentityService.is_avatar_consent_granted(db, current_user.id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Avatar clone consent is required before generation",
+        )
+
+    text = draft.edited_content or draft.content
+
+    updated = DraftService.set_avatar_status(
+        db,
+        draft_id=draft.id,
+        avatar_status="queued",
+        avatar_video_url=None,
+        avatar_provider=None,
+        avatar_model_id=request.avatar_model_id,
+        avatar_error=None,
+    )
+
+    task_result = generate_avatar.delay(
+        draft_id=draft.id,
+        user_id=current_user.id,
+        text=text,
+        avatar_style_id=request.avatar_model_id,
+        voice_audio_url=request.voice_audio_url,
+    )
+
+    return DraftAvatarGenerateResponse(
+        draft_id=draft.id,
+        queued=True,
+        avatar_status=updated.avatar_status,
+        task_id=str(task_result.id) if task_result else None,
+    )
+
+
+@router.get("/{draft_id}/avatar", response_model=DraftAvatarStatusResponse)
+async def get_draft_avatar_status(
+    draft_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get avatar generation status and delivery URL for a draft."""
+    draft = DraftService.get_draft(db, draft_id)
+    if not draft:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Draft not found")
+
+    if draft.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unauthorized: Draft belongs to different user",
+        )
+
+    return DraftAvatarStatusResponse(
+        draft_id=draft.id,
+        avatar_status=draft.avatar_status,
+        avatar_video_url=draft.avatar_video_url,
+        avatar_provider=draft.avatar_provider,
+        avatar_model_id=draft.avatar_model_id,
+        avatar_error=draft.avatar_error,
     )
 

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -22,6 +22,9 @@ from app.schemas.twin import (
     DraftVoiceGenerateRequest,
     DraftVoiceGenerateResponse,
     DraftVoiceStatusResponse,
+    DraftAvatarGenerateRequest,
+    DraftAvatarGenerateResponse,
+    DraftAvatarStatusResponse,
 )
 
 from app.schemas.identity import (
@@ -60,6 +63,9 @@ __all__ = [
     "DraftVoiceGenerateRequest",
     "DraftVoiceGenerateResponse",
     "DraftVoiceStatusResponse",
+    "DraftAvatarGenerateRequest",
+    "DraftAvatarGenerateResponse",
+    "DraftAvatarStatusResponse",
     # Identity
     "OnboardingRequest",
     "OnboardingResponse",

--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -92,6 +92,11 @@ class DraftResponse(BaseModel):
     voice_provider: Optional[str]
     voice_model_id: Optional[str]
     voice_error: Optional[str]
+    avatar_status: Optional[str]
+    avatar_video_url: Optional[str]
+    avatar_provider: Optional[str]
+    avatar_model_id: Optional[str]
+    avatar_error: Optional[str]
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -127,6 +132,33 @@ class DraftVoiceStatusResponse(BaseModel):
     voice_provider: Optional[str] = None
     voice_model_id: Optional[str] = None
     voice_error: Optional[str] = None
+
+
+class DraftAvatarGenerateRequest(BaseModel):
+    """Request payload to queue avatar generation for a draft."""
+
+    avatar_model_id: Optional[str] = None
+    voice_audio_url: Optional[str] = None
+
+
+class DraftAvatarGenerateResponse(BaseModel):
+    """Queue response for draft avatar generation."""
+
+    draft_id: str
+    queued: bool
+    avatar_status: str
+    task_id: Optional[str] = None
+
+
+class DraftAvatarStatusResponse(BaseModel):
+    """Avatar generation status for a draft."""
+
+    draft_id: str
+    avatar_status: str
+    avatar_video_url: Optional[str] = None
+    avatar_provider: Optional[str] = None
+    avatar_model_id: Optional[str] = None
+    avatar_error: Optional[str] = None
 
 
 

--- a/src/backend/app/services/draft.py
+++ b/src/backend/app/services/draft.py
@@ -305,3 +305,28 @@ class DraftService:
         db.commit()
         db.refresh(draft)
         return draft
+
+    @staticmethod
+    def set_avatar_status(
+        db: Session,
+        draft_id: str,
+        avatar_status: str,
+        avatar_video_url: str = None,
+        avatar_provider: str = None,
+        avatar_model_id: str = None,
+        avatar_error: str = None,
+    ) -> Draft:
+        """Update avatar generation fields on a draft."""
+        draft = DraftService.get_draft(db, draft_id)
+        if not draft:
+            return None
+
+        draft.avatar_status = avatar_status
+        draft.avatar_video_url = avatar_video_url
+        draft.avatar_provider = avatar_provider
+        draft.avatar_model_id = avatar_model_id
+        draft.avatar_error = avatar_error
+
+        db.commit()
+        db.refresh(draft)
+        return draft

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -580,6 +580,140 @@ class TestDraftEndpoints:
         assert data["voice_provider"] == "mock"
         assert data["voice_model_id"] == "voice-test-1"
 
+    @patch("app.routers.drafts.get_settings")
+    @patch("app.routers.drafts.generate_avatar")
+    def test_generate_avatar_queues_task_for_approved_draft(
+        self,
+        mock_generate_avatar,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Approved draft with consent should queue avatar generation task."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+        DraftService.approve_draft(test_db, draft.id, current_user.id)
+
+        # Grant avatar consent
+        client.post("/v1/identity/avatar/consent", headers=auth_headers, json={"granted": True})
+
+        mock_settings.return_value.feature_avatar_clone = True
+        mock_task = MagicMock()
+        mock_task.id = "task-avatar-123"
+        mock_generate_avatar.delay.return_value = mock_task
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/avatar/generate",
+            headers=auth_headers,
+            json={"avatar_model_id": "avatar-test-1"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["draft_id"] == draft.id
+        assert data["queued"] is True
+        assert data["avatar_status"] == "queued"
+        assert data["task_id"] == "task-avatar-123"
+
+    @patch("app.routers.drafts.get_settings")
+    def test_generate_avatar_requires_consent(
+        self,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Avatar generation should fail when consent is missing."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+        DraftService.approve_draft(test_db, draft.id, current_user.id)
+
+        mock_settings.return_value.feature_avatar_clone = True
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/avatar/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 409
+
+    @patch("app.routers.drafts.get_settings")
+    def test_generate_avatar_requires_approved_or_edited_status(
+        self,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Pending drafts cannot be queued for avatar generation."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+
+        client.post("/v1/identity/avatar/consent", headers=auth_headers, json={"granted": True})
+        mock_settings.return_value.feature_avatar_clone = True
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/avatar/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 409
+
+    @patch("app.routers.drafts.get_settings")
+    def test_generate_avatar_disabled_feature_returns_503(
+        self,
+        mock_settings,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        """Feature flag off should return service unavailable."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+        DraftService.approve_draft(test_db, draft.id, current_user.id)
+
+        client.post("/v1/identity/avatar/consent", headers=auth_headers, json={"granted": True})
+        mock_settings.return_value.feature_avatar_clone = False
+
+        response = client.post(
+            f"/v1/drafts/{draft.id}/avatar/generate",
+            headers=auth_headers,
+            json={},
+        )
+
+        assert response.status_code == 503
+
+    def test_get_draft_avatar_status(self, client, auth_headers, test_db, test_user_data):
+        """Avatar status endpoint should return persisted avatar metadata."""
+        current_user = self._get_authenticated_user(test_db, test_user_data)
+        draft = self._seed_draft(test_db, current_user)
+
+        DraftService.set_avatar_status(
+            test_db,
+            draft.id,
+            avatar_status="generated",
+            avatar_video_url="mock://avatar/test.mp4",
+            avatar_provider="mock",
+            avatar_model_id="avatar-test-1",
+            avatar_error=None,
+        )
+
+        response = client.get(f"/v1/drafts/{draft.id}/avatar", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["avatar_status"] == "generated"
+        assert data["avatar_video_url"] == "mock://avatar/test.mp4"
+        assert data["avatar_provider"] == "mock"
+        assert data["avatar_model_id"] == "avatar-test-1"
+
 
 class TestPushTokenEndpoints:
     """Tests for device push-token registration"""


### PR DESCRIPTION
## Summary
Implements Phase 7 PR C on top of PR B by adding draft-level avatar generation and status endpoints, aligned with the existing voice generation flow.

## What Changed
- Added draft avatar schemas:
  - `DraftAvatarGenerateRequest`
  - `DraftAvatarGenerateResponse`
  - `DraftAvatarStatusResponse`
- Extended `DraftResponse` with avatar fields:
  - `avatar_status`, `avatar_video_url`, `avatar_provider`, `avatar_model_id`, `avatar_error`
- Exported new schemas in `app/schemas/__init__.py`
- Added draft service helper:
  - `set_avatar_status(...)`
- Added draft router endpoints:
  - `POST /v1/drafts/{draft_id}/avatar/generate`
  - `GET /v1/drafts/{draft_id}/avatar`
- Enforced required checks for generation:
  - feature flag `feature_avatar_clone` enabled
  - draft ownership
  - draft status must be `approved` or `edited`
  - avatar consent must be granted
- Queues background avatar task via `generate_avatar.delay(...)`
- Added endpoint tests in `tests/test_endpoints.py` for:
  - queue success
  - consent required
  - status required
  - feature disabled
  - status retrieval

## Validation
- `tests/test_endpoints.py`: 49 passed
- Full backend suite: 241 passed

## Notes
- This completes the Phase 7 stacked implementation path:
  - PR A: foundation
  - PR B: consent/enrollment
  - PR C: draft generation/status delivery APIs