### PR TITLE
Phase 8 PR B: Weekly Digest Summary API

### DIFF
--- a/src/backend/app/routers/twin.py
+++ b/src/backend/app/routers/twin.py
@@ -9,7 +9,13 @@ from app.database import get_db
 from app.middleware.auth import get_current_user
 from app.models import User
 from app.services import TwinService
-from app.schemas import TwinResponse, TwinStatsResponse, TwinQualitySummaryResponse, UpdateTwinRequest
+from app.schemas import (
+    TwinResponse,
+    TwinStatsResponse,
+    TwinQualitySummaryResponse,
+    TwinWeeklyDigestResponse,
+    UpdateTwinRequest,
+)
 
 router = APIRouter(tags=["twin"])
 
@@ -142,4 +148,21 @@ async def get_twin_quality_summary(
         )
 
     return TwinQualitySummaryResponse(**summary)
+
+
+@router.get("/weekly-digest", response_model=TwinWeeklyDigestResponse)
+async def get_twin_weekly_digest(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Phase 8 beta weekly digest preview for the current twin."""
+    digest = TwinService.get_weekly_digest_summary(db, current_user.id)
+
+    if not digest:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Twin not found",
+        )
+
+    return TwinWeeklyDigestResponse(**digest)
 

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -16,6 +16,7 @@ from app.schemas.twin import (
     TwinResponse,
     TwinStatsResponse,
     TwinQualitySummaryResponse,
+    TwinWeeklyDigestResponse,
     UpdateTwinRequest,
     MessageResponse,
     DraftResponse,
@@ -57,6 +58,7 @@ __all__ = [
     "TwinResponse",
     "TwinStatsResponse",
     "TwinQualitySummaryResponse",
+    "TwinWeeklyDigestResponse",
     "UpdateTwinRequest",
     # Messages & Drafts
     "MessageResponse",

--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -54,6 +54,21 @@ class TwinQualitySummaryResponse(BaseModel):
     recommendation: str
 
 
+class TwinWeeklyDigestResponse(BaseModel):
+    """Phase 8 weekly digest summary payload."""
+
+    twin_id: str
+    week_start: datetime
+    week_end: datetime
+    messages_received_7d: int
+    drafts_generated_7d: int
+    drafts_handled_7d: int
+    approval_rate_7d: float
+    top_channel: Optional[str] = None
+    pending_drafts: int
+    summary_line: str
+
+
 class UpdateTwinRequest(BaseModel):
     """Request to update twin profile"""
     domain: Optional[str] = None

--- a/src/backend/app/services/twin.py
+++ b/src/backend/app/services/twin.py
@@ -203,3 +203,63 @@ class TwinService:
             "quality_label": quality_label,
             "recommendation": recommendation,
         }
+
+    @staticmethod
+    def get_weekly_digest_summary(db: Session, user_id: str) -> dict:
+        """Return a compact weekly digest summary for beta launch reporting."""
+        from app.models import Draft, Message
+
+        twin = TwinService.get_twin(db, user_id)
+        if not twin:
+            return None
+
+        now = datetime.now(UTC).replace(tzinfo=None)
+        since = now - timedelta(days=7)
+
+        messages_7d = db.query(Message).filter(
+            Message.user_id == user_id,
+            Message.created_at >= since,
+        )
+        drafts_7d = db.query(Draft).filter(
+            Draft.user_id == user_id,
+            Draft.created_at >= since,
+        )
+
+        messages_received_7d = messages_7d.count()
+        drafts_generated_7d = drafts_7d.count()
+
+        drafts_handled_7d = drafts_7d.filter(Draft.status.in_(["approved", "edited", "sent"])).count()
+
+        approved_edited_count = drafts_7d.filter(Draft.status.in_(["approved", "edited"])).count()
+        rejected_count = drafts_7d.filter(Draft.status == "rejected").count()
+        decided_count = approved_edited_count + rejected_count
+        approval_rate_7d = round(approved_edited_count / decided_count, 4) if decided_count > 0 else 0.0
+
+        top_channel_row = messages_7d.with_entities(
+            Message.channel,
+            func.count(Message.id).label("count"),
+        ).group_by(Message.channel).order_by(func.count(Message.id).desc()).first()
+        top_channel = top_channel_row[0] if top_channel_row else None
+
+        pending_drafts = db.query(Draft).filter(
+            Draft.user_id == user_id,
+            Draft.status == "pending_approval",
+        ).count()
+
+        summary_line = (
+            f"Your twin handled {drafts_handled_7d} messages this week "
+            f"with {int(round(approval_rate_7d * 100))}% approval."
+        )
+
+        return {
+            "twin_id": twin.id,
+            "week_start": since,
+            "week_end": now,
+            "messages_received_7d": messages_received_7d,
+            "drafts_generated_7d": drafts_generated_7d,
+            "drafts_handled_7d": drafts_handled_7d,
+            "approval_rate_7d": approval_rate_7d,
+            "top_channel": top_channel,
+            "pending_drafts": pending_drafts,
+            "summary_line": summary_line,
+        }

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -134,11 +134,18 @@ class TestTwinEndpoints:
     """Test twin endpoints"""
 
     @staticmethod
-    def _seed_quality_draft(test_db, user, *, status: str, latency: int = 400):
+    def _seed_quality_draft(
+        test_db,
+        user,
+        *,
+        status: str,
+        latency: int = 400,
+        channel: str = "instagram_dm",
+    ):
         message = MessageService.create_message(
             test_db,
             user.id,
-            "instagram_dm",
+            channel,
             f"sender-{status}-{latency}",
             "Quality Sender",
             "Quality check message",
@@ -248,6 +255,29 @@ class TestTwinEndpoints:
 
     def test_get_twin_quality_summary_unauthorized(self, client):
         response = client.get("/v1/twin/quality-summary")
+        assert response.status_code == 403
+
+    def test_get_twin_weekly_digest(self, client, auth_headers, test_db, test_user_data):
+        user = test_db.query(User).filter(User.email == test_user_data["email"]).first()
+        self._seed_quality_draft(test_db, user, status="approved", latency=300, channel="gmail")
+        self._seed_quality_draft(test_db, user, status="edited", latency=450, channel="gmail")
+        self._seed_quality_draft(test_db, user, status="rejected", latency=700, channel="instagram_dm")
+
+        response = client.get("/v1/twin/weekly-digest", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["twin_id"] == user.twin.id
+        assert data["messages_received_7d"] == 3
+        assert data["drafts_generated_7d"] == 3
+        assert data["drafts_handled_7d"] == 2
+        assert data["approval_rate_7d"] == pytest.approx(0.6667, abs=0.001)
+        assert data["top_channel"] == "gmail"
+        assert isinstance(data["summary_line"], str)
+        assert "handled" in data["summary_line"]
+
+    def test_get_twin_weekly_digest_unauthorized(self, client):
+        response = client.get("/v1/twin/weekly-digest")
         assert response.status_code == 403
 
 


### PR DESCRIPTION
## Summary
- add weekly digest response schema for Phase 8 beta launch reporting
- implement weekly digest aggregation in TwinService
- expose GET /v1/twin/weekly-digest endpoint
- add endpoint tests for success and unauthorized access

## Validation
- python -m pytest tests/test_endpoints.py -q
- python -m pytest -q