### PR TITLE
Phase 8 PR C: Onboarding Status API

### DIFF
--- a/src/backend/app/routers/identity.py
+++ b/src/backend/app/routers/identity.py
@@ -18,6 +18,7 @@ from app.schemas.identity import (
     IdentityProfileResponse,
     UpdateIdentityRequest,
     IdentityConfidenceResponse,
+    IdentityOnboardingStatusResponse,
     VoiceConsentRequest,
     VoiceConsentResponse,
     VoiceEnrollmentRequest,
@@ -262,6 +263,16 @@ async def get_identity_confidence(
     """
     result = IdentityService.get_confidence_score(db, current_user.id)
     return IdentityConfidenceResponse(**result)
+
+
+@router.get("/onboarding/status", response_model=IdentityOnboardingStatusResponse)
+async def get_onboarding_status(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return onboarding completion, blockers, and next-step guidance."""
+    status_payload = IdentityService.get_onboarding_status(db, current_user.id)
+    return IdentityOnboardingStatusResponse(**status_payload)
 
 
 # ── Voice Clone (Phase 6 PR B) ──────────────────────────────────────────────

--- a/src/backend/app/routers/twin.py
+++ b/src/backend/app/routers/twin.py
@@ -9,7 +9,13 @@ from app.database import get_db
 from app.middleware.auth import get_current_user
 from app.models import User
 from app.services import TwinService
-from app.schemas import TwinResponse, TwinStatsResponse, TwinQualitySummaryResponse, UpdateTwinRequest
+from app.schemas import (
+    TwinResponse,
+    TwinStatsResponse,
+    TwinQualitySummaryResponse,
+    TwinWeeklyDigestResponse,
+    UpdateTwinRequest,
+)
 
 router = APIRouter(tags=["twin"])
 
@@ -142,4 +148,21 @@ async def get_twin_quality_summary(
         )
 
     return TwinQualitySummaryResponse(**summary)
+
+
+@router.get("/weekly-digest", response_model=TwinWeeklyDigestResponse)
+async def get_twin_weekly_digest(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Phase 8 beta weekly digest preview for the current twin."""
+    digest = TwinService.get_weekly_digest_summary(db, current_user.id)
+
+    if not digest:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Twin not found",
+        )
+
+    return TwinWeeklyDigestResponse(**digest)
 

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -16,6 +16,7 @@ from app.schemas.twin import (
     TwinResponse,
     TwinStatsResponse,
     TwinQualitySummaryResponse,
+    TwinWeeklyDigestResponse,
     UpdateTwinRequest,
     MessageResponse,
     DraftResponse,
@@ -57,6 +58,7 @@ __all__ = [
     "TwinResponse",
     "TwinStatsResponse",
     "TwinQualitySummaryResponse",
+    "TwinWeeklyDigestResponse",
     "UpdateTwinRequest",
     # Messages & Drafts
     "MessageResponse",

--- a/src/backend/app/schemas/__init__.py
+++ b/src/backend/app/schemas/__init__.py
@@ -37,6 +37,7 @@ from app.schemas.identity import (
     IdentityProfileResponse,
     UpdateIdentityRequest,
     IdentityConfidenceResponse,
+    IdentityOnboardingStatusResponse,
 )
 
 from app.schemas.channels import (
@@ -78,6 +79,7 @@ __all__ = [
     "IdentityProfileResponse",
     "UpdateIdentityRequest",
     "IdentityConfidenceResponse",
+    "IdentityOnboardingStatusResponse",
     # Channels
     "ChannelConnectRequest",
     "ChannelConnectResponse",

--- a/src/backend/app/schemas/identity.py
+++ b/src/backend/app/schemas/identity.py
@@ -116,6 +116,18 @@ class IdentityConfidenceResponse(BaseModel):
     message: str           # human-readable status
 
 
+class IdentityOnboardingStatusResponse(BaseModel):
+    """Onboarding completion and drop-off guidance for Phase 8 polish."""
+
+    onboarding_complete: bool
+    completion_percent: int
+    profile_complete: bool
+    connected_channels: List[str]
+    missing_channels: List[str]
+    blockers: List[str]
+    next_step: str
+
+
 class VoiceConsentRequest(BaseModel):
     """Grant or revoke voice clone consent."""
 

--- a/src/backend/app/schemas/twin.py
+++ b/src/backend/app/schemas/twin.py
@@ -54,6 +54,21 @@ class TwinQualitySummaryResponse(BaseModel):
     recommendation: str
 
 
+class TwinWeeklyDigestResponse(BaseModel):
+    """Phase 8 weekly digest summary payload."""
+
+    twin_id: str
+    week_start: datetime
+    week_end: datetime
+    messages_received_7d: int
+    drafts_generated_7d: int
+    drafts_handled_7d: int
+    approval_rate_7d: float
+    top_channel: Optional[str] = None
+    pending_drafts: int
+    summary_line: str
+
+
 class UpdateTwinRequest(BaseModel):
     """Request to update twin profile"""
     domain: Optional[str] = None

--- a/src/backend/app/services/identity.py
+++ b/src/backend/app/services/identity.py
@@ -6,7 +6,7 @@ from datetime import datetime, UTC
 
 from sqlalchemy.orm import Session
 from sqlalchemy import and_
-from app.models import IdentityProfile, Topic, Twin, Consent
+from app.models import IdentityProfile, Topic, Twin, Consent, ChannelCredential
 
 
 class IdentityService:
@@ -401,3 +401,63 @@ class IdentityService:
         db.commit()
         db.refresh(profile)
         return profile
+
+    @staticmethod
+    def get_onboarding_status(db: Session, user_id: str) -> dict:
+        """Return onboarding completion state and actionable next-step guidance."""
+        profile = IdentityService.get_identity_profile(db, user_id)
+        topics_avoided = IdentityService.get_topics_avoided(db, user_id)
+        twin = db.query(Twin).filter(Twin.user_id == user_id).first()
+
+        active_channels = db.query(ChannelCredential).filter(
+            ChannelCredential.user_id == user_id,
+            ChannelCredential.is_active.is_(True),
+        ).all()
+        connected_channels = sorted(list({c.channel for c in active_channels}))
+
+        required_channels = ["instagram", "gmail"]
+        missing_channels = [c for c in required_channels if c not in connected_channels]
+
+        profile_complete = bool(
+            profile
+            and profile.vocabulary_description
+            and profile.communication_style
+            and topics_avoided
+        )
+        has_channel_connected = len(connected_channels) > 0
+
+        completed_steps = [
+            bool(twin),
+            profile_complete,
+            has_channel_connected,
+        ]
+        completion_percent = int(round((sum(completed_steps) / len(completed_steps)) * 100))
+
+        blockers = []
+        if not profile_complete:
+            blockers.append("complete_onboarding")
+        if not has_channel_connected:
+            blockers.append("connect_first_channel")
+        elif "instagram" not in connected_channels:
+            blockers.append("connect_instagram_business_account")
+
+        if not profile_complete:
+            next_step = "Complete onboarding questionnaire to improve twin quality."
+        elif not has_channel_connected:
+            next_step = "Connect Instagram or Gmail to start receiving real messages."
+        elif "instagram" not in connected_channels:
+            next_step = "Connect an Instagram Business account to reduce onboarding drop-off risk."
+        else:
+            next_step = "Onboarding looks strong. Continue by reviewing and approving first drafts."
+
+        onboarding_complete = profile_complete and has_channel_connected
+
+        return {
+            "onboarding_complete": onboarding_complete,
+            "completion_percent": completion_percent,
+            "profile_complete": profile_complete,
+            "connected_channels": connected_channels,
+            "missing_channels": missing_channels,
+            "blockers": blockers,
+            "next_step": next_step,
+        }

--- a/src/backend/app/services/twin.py
+++ b/src/backend/app/services/twin.py
@@ -203,3 +203,63 @@ class TwinService:
             "quality_label": quality_label,
             "recommendation": recommendation,
         }
+
+    @staticmethod
+    def get_weekly_digest_summary(db: Session, user_id: str) -> dict:
+        """Return a compact weekly digest summary for beta launch reporting."""
+        from app.models import Draft, Message
+
+        twin = TwinService.get_twin(db, user_id)
+        if not twin:
+            return None
+
+        now = datetime.now(UTC).replace(tzinfo=None)
+        since = now - timedelta(days=7)
+
+        messages_7d = db.query(Message).filter(
+            Message.user_id == user_id,
+            Message.created_at >= since,
+        )
+        drafts_7d = db.query(Draft).filter(
+            Draft.user_id == user_id,
+            Draft.created_at >= since,
+        )
+
+        messages_received_7d = messages_7d.count()
+        drafts_generated_7d = drafts_7d.count()
+
+        drafts_handled_7d = drafts_7d.filter(Draft.status.in_(["approved", "edited", "sent"])).count()
+
+        approved_edited_count = drafts_7d.filter(Draft.status.in_(["approved", "edited"])).count()
+        rejected_count = drafts_7d.filter(Draft.status == "rejected").count()
+        decided_count = approved_edited_count + rejected_count
+        approval_rate_7d = round(approved_edited_count / decided_count, 4) if decided_count > 0 else 0.0
+
+        top_channel_row = messages_7d.with_entities(
+            Message.channel,
+            func.count(Message.id).label("count"),
+        ).group_by(Message.channel).order_by(func.count(Message.id).desc()).first()
+        top_channel = top_channel_row[0] if top_channel_row else None
+
+        pending_drafts = db.query(Draft).filter(
+            Draft.user_id == user_id,
+            Draft.status == "pending_approval",
+        ).count()
+
+        summary_line = (
+            f"Your twin handled {drafts_handled_7d} messages this week "
+            f"with {int(round(approval_rate_7d * 100))}% approval."
+        )
+
+        return {
+            "twin_id": twin.id,
+            "week_start": since,
+            "week_end": now,
+            "messages_received_7d": messages_received_7d,
+            "drafts_generated_7d": drafts_generated_7d,
+            "drafts_handled_7d": drafts_handled_7d,
+            "approval_rate_7d": approval_rate_7d,
+            "top_channel": top_channel,
+            "pending_drafts": pending_drafts,
+            "summary_line": summary_line,
+        }

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -134,11 +134,18 @@ class TestTwinEndpoints:
     """Test twin endpoints"""
 
     @staticmethod
-    def _seed_quality_draft(test_db, user, *, status: str, latency: int = 400):
+    def _seed_quality_draft(
+        test_db,
+        user,
+        *,
+        status: str,
+        latency: int = 400,
+        channel: str = "instagram_dm",
+    ):
         message = MessageService.create_message(
             test_db,
             user.id,
-            "instagram_dm",
+            channel,
             f"sender-{status}-{latency}",
             "Quality Sender",
             "Quality check message",
@@ -248,6 +255,29 @@ class TestTwinEndpoints:
 
     def test_get_twin_quality_summary_unauthorized(self, client):
         response = client.get("/v1/twin/quality-summary")
+        assert response.status_code == 403
+
+    def test_get_twin_weekly_digest(self, client, auth_headers, test_db, test_user_data):
+        user = test_db.query(User).filter(User.email == test_user_data["email"]).first()
+        self._seed_quality_draft(test_db, user, status="approved", latency=300, channel="gmail")
+        self._seed_quality_draft(test_db, user, status="edited", latency=450, channel="gmail")
+        self._seed_quality_draft(test_db, user, status="rejected", latency=700, channel="instagram_dm")
+
+        response = client.get("/v1/twin/weekly-digest", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["twin_id"] == user.twin.id
+        assert data["messages_received_7d"] == 3
+        assert data["drafts_generated_7d"] == 3
+        assert data["drafts_handled_7d"] == 2
+        assert data["approval_rate_7d"] == pytest.approx(0.6667, abs=0.001)
+        assert data["top_channel"] == "gmail"
+        assert isinstance(data["summary_line"], str)
+        assert "handled" in data["summary_line"]
+
+    def test_get_twin_weekly_digest_unauthorized(self, client):
+        response = client.get("/v1/twin/weekly-digest")
         assert response.status_code == 403
 
 

--- a/src/backend/tests/test_identity.py
+++ b/src/backend/tests/test_identity.py
@@ -13,6 +13,7 @@ GET  /v1/identity/confidence
 """
 
 import pytest
+from app.models import ChannelCredential, User
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -285,6 +286,52 @@ class TestConfidence:
     def test_confidence_requires_auth(self, client):
         """Unauthenticated request returns 403 (middleware behaviour)."""
         response = client.get("/v1/identity/confidence")
+        assert response.status_code == 403
+
+
+class TestOnboardingStatus:
+    def test_onboarding_status_before_onboarding(self, client, auth_headers):
+        response = client.get("/v1/identity/onboarding/status", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["onboarding_complete"] is False
+        assert data["profile_complete"] is False
+        assert data["completion_percent"] == 33
+        assert "complete_onboarding" in data["blockers"]
+        assert "connect_first_channel" in data["blockers"]
+
+    def test_onboarding_status_after_onboarding_and_channel_connect(
+        self,
+        client,
+        auth_headers,
+        test_db,
+        test_user_data,
+    ):
+        client.post("/v1/identity/onboard", json=ONBOARDING_PAYLOAD, headers=auth_headers)
+
+        user = test_db.query(User).filter(User.email == test_user_data["email"]).first()
+        credential = ChannelCredential(
+            user_id=user.id,
+            channel="instagram",
+            credential_type="oauth_token",
+            credential_value="token-123",
+            is_active=True,
+        )
+        test_db.add(credential)
+        test_db.commit()
+
+        response = client.get("/v1/identity/onboarding/status", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["onboarding_complete"] is True
+        assert data["profile_complete"] is True
+        assert data["completion_percent"] == 100
+        assert "instagram" in data["connected_channels"]
+        assert "gmail" in data["missing_channels"]
+        assert data["blockers"] == []
+
+    def test_onboarding_status_requires_auth(self, client):
+        response = client.get("/v1/identity/onboarding/status")
         assert response.status_code == 403
 
 


### PR DESCRIPTION
## Summary
- add onboarding status response schema for Phase 8 onboarding polish
- implement onboarding progress + blocker detection in IdentityService
- add GET /v1/identity/onboarding/status endpoint
- add identity tests for incomplete, complete, and unauthorized flows

## Validation
- python -m pytest tests/test_identity.py -q
- python -m pytest -q