### PR TITLE
Phase 8 PR F: Referral Acceptance Hardening

### DIFF
--- a/src/backend/app/routers/referrals.py
+++ b/src/backend/app/routers/referrals.py
@@ -52,7 +52,18 @@ async def accept_referral_invite(
     db: Session = Depends(get_db),
 ):
     """Accept a referral invite using a referral code."""
-    invite = ReferralService.accept_invite(db, current_user.id, request.referral_code)
+    try:
+        invite = ReferralService.accept_invite(db, current_user.id, request.referral_code)
+    except ValueError as exc:
+        detail_map = {
+            "self_referral_not_allowed": "Cannot accept your own referral code",
+            "referral_code_already_claimed": "Referral code already claimed by another user",
+        }
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=detail_map.get(str(exc), "Referral acceptance conflict"),
+        ) from exc
+
     if not invite:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/backend/app/services/referral.py
+++ b/src/backend/app/services/referral.py
@@ -50,12 +50,16 @@ class ReferralService:
             return None
 
         if invite.referrer_user_id == invitee_user_id:
-            return None
+            raise ValueError("self_referral_not_allowed")
 
-        if invite.status != "accepted":
-            invite.status = "accepted"
-            invite.invitee_user_id = invitee_user_id
-            invite.accepted_at = datetime.now(UTC).replace(tzinfo=None)
+        if invite.status == "accepted":
+            if invite.invitee_user_id == invitee_user_id:
+                return invite
+            raise ValueError("referral_code_already_claimed")
+
+        invite.status = "accepted"
+        invite.invitee_user_id = invitee_user_id
+        invite.accepted_at = datetime.now(UTC).replace(tzinfo=None)
 
         db.add(invite)
         db.commit()

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -989,6 +989,59 @@ class TestReferralEndpoints:
         response = client.get("/v1/referrals/summary")
         assert response.status_code == 403
 
+    def test_referral_code_cannot_be_claimed_by_second_user(self, client, auth_headers):
+        invite_response = client.post(
+            "/v1/referrals/invite",
+            headers=auth_headers,
+            json={"invitee_email": "creator4@example.com"},
+        )
+        code = invite_response.json()["referral_code"]
+
+        first_invitee = {
+            "email": "creator4@example.com",
+            "password": "TestPassword123",
+            "name": "Creator Four",
+        }
+        second_invitee = {
+            "email": "creator5@example.com",
+            "password": "TestPassword123",
+            "name": "Creator Five",
+        }
+        assert client.post("/v1/auth/signup", json=first_invitee).status_code == 201
+        assert client.post("/v1/auth/signup", json=second_invitee).status_code == 201
+
+        first_headers = self._login_headers(client, first_invitee["email"], first_invitee["password"])
+        second_headers = self._login_headers(client, second_invitee["email"], second_invitee["password"])
+
+        first_accept = client.post(
+            "/v1/referrals/accept",
+            headers=first_headers,
+            json={"referral_code": code},
+        )
+        assert first_accept.status_code == 200
+
+        second_accept = client.post(
+            "/v1/referrals/accept",
+            headers=second_headers,
+            json={"referral_code": code},
+        )
+        assert second_accept.status_code == 409
+
+    def test_referrer_cannot_accept_own_referral_code(self, client, auth_headers):
+        invite_response = client.post(
+            "/v1/referrals/invite",
+            headers=auth_headers,
+            json={"invitee_email": "creator6@example.com"},
+        )
+        code = invite_response.json()["referral_code"]
+
+        accept_response = client.post(
+            "/v1/referrals/accept",
+            headers=auth_headers,
+            json={"referral_code": code},
+        )
+        assert accept_response.status_code == 409
+
 
 class TestHealthEndpoint:
     """Test health check endpoint"""


### PR DESCRIPTION
## Summary
- harden referral acceptance flow with explicit conflict handling
- block self-referral acceptance attempts
- block second-user claims on already accepted referral codes
- preserve idempotent re-accept behavior for the same invitee
- add endpoint tests for self-claim and duplicate-claim conflicts

## Validation
- python -m pytest tests/test_endpoints.py -q
- python -m pytest -q