### PR TITLE
Phase 8 PR H: Feature Dependency Readiness Checks

### DIFF
--- a/src/backend/app/routers/health.py
+++ b/src/backend/app/routers/health.py
@@ -14,6 +14,10 @@ from app.database import get_db
 router = APIRouter()
 
 
+def _has_value(value) -> bool:
+    return bool(value and str(value).strip())
+
+
 @router.get("/health")
 async def health_check():
     """
@@ -52,6 +56,58 @@ async def readiness_check(db: Session = Depends(get_db)):
     checks["jwt_secret"] = {"ok": jwt_secret_ok}
     if jwt_reason:
         checks["jwt_secret"]["reason"] = jwt_reason
+
+    instagram_ok = True
+    instagram_reason = None
+    if settings.feature_instagram:
+        required_instagram = [
+            settings.meta_app_id,
+            settings.meta_app_secret,
+            settings.meta_verify_token,
+            settings.meta_oauth_redirect_uri,
+        ]
+        instagram_ok = all(_has_value(v) for v in required_instagram)
+        if not instagram_ok:
+            instagram_reason = "Instagram enabled but Meta OAuth/webhook settings are incomplete"
+    checks["feature_instagram"] = {"ok": instagram_ok}
+    if instagram_reason:
+        checks["feature_instagram"]["reason"] = instagram_reason
+
+    gmail_ok = True
+    gmail_reason = None
+    if settings.feature_gmail:
+        required_gmail = [
+            settings.google_oauth_client_id,
+            settings.google_oauth_client_secret,
+            settings.google_oauth_redirect_uri,
+            settings.google_pubsub_topic,
+        ]
+        gmail_ok = all(_has_value(v) for v in required_gmail)
+        if not gmail_ok:
+            gmail_reason = "Gmail enabled but OAuth/PubSub settings are incomplete"
+    checks["feature_gmail"] = {"ok": gmail_ok}
+    if gmail_reason:
+        checks["feature_gmail"]["reason"] = gmail_reason
+
+    voice_provider_ok = True
+    voice_provider_reason = None
+    if settings.feature_voice_clone and settings.voice_provider == "elevenlabs":
+        voice_provider_ok = _has_value(settings.elevenlabs_api_key)
+        if not voice_provider_ok:
+            voice_provider_reason = "Voice clone enabled with ElevenLabs but API key is missing"
+    checks["feature_voice_clone"] = {"ok": voice_provider_ok}
+    if voice_provider_reason:
+        checks["feature_voice_clone"]["reason"] = voice_provider_reason
+
+    avatar_provider_ok = True
+    avatar_provider_reason = None
+    if settings.feature_avatar_clone and settings.avatar_provider == "heygen":
+        avatar_provider_ok = _has_value(settings.heygen_api_key)
+        if not avatar_provider_ok:
+            avatar_provider_reason = "Avatar clone enabled with HeyGen but API key is missing"
+    checks["feature_avatar_clone"] = {"ok": avatar_provider_ok}
+    if avatar_provider_reason:
+        checks["feature_avatar_clone"]["reason"] = avatar_provider_reason
 
     is_ready = all(item["ok"] for item in checks.values())
     payload = {

--- a/src/backend/tests/test_endpoints.py
+++ b/src/backend/tests/test_endpoints.py
@@ -1069,6 +1069,22 @@ class TestHealthEndpoint:
             environment="production",
             enforce_production_jwt_secret=True,
             jwt_secret_key="dev-secret-key-change-in-production",
+            feature_instagram=False,
+            meta_app_id="",
+            meta_app_secret="",
+            meta_verify_token="",
+            meta_oauth_redirect_uri="",
+            feature_gmail=False,
+            google_oauth_client_id="",
+            google_oauth_client_secret="",
+            google_oauth_redirect_uri="",
+            google_pubsub_topic="",
+            feature_voice_clone=False,
+            voice_provider="mock",
+            elevenlabs_api_key="",
+            feature_avatar_clone=False,
+            avatar_provider="mock",
+            heygen_api_key="",
         )
 
         response = client.get("/ready")
@@ -1076,3 +1092,65 @@ class TestHealthEndpoint:
         data = response.json()
         assert data["status"] == "not_ready"
         assert data["checks"]["jwt_secret"]["ok"] is False
+
+    @patch("app.routers.health.get_settings")
+    def test_readiness_check_detects_missing_instagram_config(self, mock_get_settings, client):
+        mock_get_settings.return_value = SimpleNamespace(
+            environment="development",
+            enforce_production_jwt_secret=True,
+            jwt_secret_key="dev-secret-key-change-in-production",
+            feature_instagram=True,
+            meta_app_id="",
+            meta_app_secret="secret",
+            meta_verify_token="verify",
+            meta_oauth_redirect_uri="https://api.selph.ai/v1/channels/instagram/callback",
+            feature_gmail=False,
+            google_oauth_client_id="",
+            google_oauth_client_secret="",
+            google_oauth_redirect_uri="",
+            google_pubsub_topic="",
+            feature_voice_clone=False,
+            voice_provider="mock",
+            elevenlabs_api_key="",
+            feature_avatar_clone=False,
+            avatar_provider="mock",
+            heygen_api_key="",
+        )
+
+        response = client.get("/ready")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["checks"]["feature_instagram"]["ok"] is False
+
+    @patch("app.routers.health.get_settings")
+    def test_readiness_check_feature_dependencies_all_configured(self, mock_get_settings, client):
+        mock_get_settings.return_value = SimpleNamespace(
+            environment="production",
+            enforce_production_jwt_secret=True,
+            jwt_secret_key="this-is-a-very-strong-production-secret-key-12345",
+            feature_instagram=True,
+            meta_app_id="meta-app-id",
+            meta_app_secret="meta-app-secret",
+            meta_verify_token="meta-verify-token",
+            meta_oauth_redirect_uri="https://api.selph.ai/v1/channels/instagram/callback",
+            feature_gmail=True,
+            google_oauth_client_id="google-client-id",
+            google_oauth_client_secret="google-client-secret",
+            google_oauth_redirect_uri="https://api.selph.ai/v1/channels/gmail/callback",
+            google_pubsub_topic="projects/selph/topics/gmail-push",
+            feature_voice_clone=True,
+            voice_provider="elevenlabs",
+            elevenlabs_api_key="elevenlabs-key",
+            feature_avatar_clone=True,
+            avatar_provider="heygen",
+            heygen_api_key="heygen-key",
+        )
+
+        response = client.get("/ready")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["checks"]["feature_instagram"]["ok"] is True
+        assert data["checks"]["feature_gmail"]["ok"] is True
+        assert data["checks"]["feature_voice_clone"]["ok"] is True
+        assert data["checks"]["feature_avatar_clone"]["ok"] is True


### PR DESCRIPTION
## Summary
- extend /ready checks to validate feature-flag dependencies for Instagram, Gmail, voice clone, and avatar clone
- keep readiness payload structured per-check with reasons on failure
- add endpoint tests for missing feature config and fully configured feature dependencies

## Validation
- python -m pytest tests/test_endpoints.py -q
- python -m pytest -q