### PR TITLE
Phase 8 PR J: Merge-Train Validation Report

### DIFF
--- a/docs/06-implementation/PHASE_8_MERGE_TRAIN_VALIDATION_REPORT.md
+++ b/docs/06-implementation/PHASE_8_MERGE_TRAIN_VALIDATION_REPORT.md
@@ -1,0 +1,75 @@
+# Phase 8 Merge Train Validation Report
+
+Date: 2026-04-28
+Report Branch: feature/phase8-pr-i
+
+## Scope
+Validation snapshot for stacked Phase 8 PRs #26 through #34 before merge into `main`.
+
+## 1) Branch and Chain Snapshot
+
+Current branch during validation:
+- `feature/phase8-pr-i`
+
+Observed stacked commit chain (latest first):
+- `dd09bbc` Phase 8 PR I docs prep
+- `7e074e4` Phase 8 PR H feature dependency readiness checks
+- `b7bfeff` Phase 8 PR G readiness hardening
+- `1b540f8` Phase 8 PR F referral acceptance hardening
+- `d080b64` Phase 8 PR E performance summary endpoint
+- `404016b` Phase 8 PR D referral system API
+- `4a9e298` Phase 8 PR C onboarding status endpoint
+- `8a4876b` Phase 8 PR B weekly digest summary API
+- `d3c214f` Phase 8 PR A quality summary API
+
+## 2) Pull Request Status Matrix
+
+All PRs are currently OPEN and report mergeStateStatus `CLEAN`.
+
+| PR | Title | Base | Head | State | Merge State |
+|---|---|---|---|---|---|
+| #26 | Phase 8 PR A: Twin Quality Summary API | main | feature/phase8-pr-a | OPEN | CLEAN |
+| #27 | Phase 8 PR B: Weekly Digest Summary API | feature/phase8-pr-a | feature/phase8-pr-b | OPEN | CLEAN |
+| #28 | Phase 8 PR C: Onboarding Status API | feature/phase8-pr-b | feature/phase8-pr-c | OPEN | CLEAN |
+| #29 | Phase 8 PR D: Referral System API | feature/phase8-pr-c | feature/phase8-pr-d | OPEN | CLEAN |
+| #30 | Phase 8 PR E: Performance Summary API | feature/phase8-pr-d | feature/phase8-pr-e | OPEN | CLEAN |
+| #31 | Phase 8 PR F: Referral Acceptance Hardening | feature/phase8-pr-e | feature/phase8-pr-f | OPEN | CLEAN |
+| #32 | Phase 8 PR G: Readiness Check Hardening | feature/phase8-pr-f | feature/phase8-pr-g | OPEN | CLEAN |
+| #33 | Phase 8 PR H: Feature Dependency Readiness Checks | feature/phase8-pr-g | feature/phase8-pr-h | OPEN | CLEAN |
+| #34 | Phase 8 PR I: Merge Train and Release Notes Prep | feature/phase8-pr-h | feature/phase8-pr-i | OPEN | CLEAN |
+
+## 3) Validation Commands Executed
+
+Commands executed on this report branch:
+- `git status -sb`
+- `git branch --show-current`
+- `git log --oneline --decorate -n 12`
+- `gh pr view 26..34 --json ...` (queried individually)
+- `python -m pytest -q` from `src/backend`
+
+Test result:
+- Full backend suite: `261 passed`
+
+## 4) Merge Recommendation
+
+Recommended merge order:
+1. #26
+2. #27
+3. #28
+4. #29
+5. #30
+6. #31
+7. #32
+8. #33
+9. #34
+
+Rationale:
+- Base/head stack is linear with no merge-conflict signal (`CLEAN`) at capture time.
+- Latest full regression passed on stack tip.
+
+## 5) Outstanding Non-Blocking Note
+
+Untracked local file present during validation:
+- `docs/06-implementation/RELEASE_DRAFT_v0.8.0.md`
+
+This file was excluded from commit scope and does not affect merge-train validation results.

--- a/docs/06-implementation/RELEASE_DRAFT_v0.9.0.md
+++ b/docs/06-implementation/RELEASE_DRAFT_v0.9.0.md
@@ -46,10 +46,11 @@ This release packages the Phase 8 beta-launch backend stack with creator-facing 
 - #31 Phase 8 PR F: Referral Acceptance Hardening
 - #32 Phase 8 PR G: Readiness Check Hardening
 - #33 Phase 8 PR H: Feature Dependency Readiness Checks
+- #34 Phase 8 PR I: Merge Train and Release Notes Prep
 
 ## Validation
 - Endpoint suite expanded and passing across all new APIs.
-- Latest full backend regression after Phase 8 stack:
+- Latest full backend regression on merge-train tip:
   - `261 passed`
 
 ## Release Notes


### PR DESCRIPTION
## Summary
- add Phase 8 merge-train validation report with PR status matrix and command outputs
- update v0.9.0 release draft to include PR I and tip-of-stack validation wording

## Validation Commands Captured
- git status -sb
- git branch --show-current
- git log --oneline --decorate -n 12
- gh pr view 26..34 status queries
- python -m pytest -q (261 passed)